### PR TITLE
entproto - adding FieldMap 

### DIFF
--- a/entproto/fieldmap.go
+++ b/entproto/fieldmap.go
@@ -77,7 +77,6 @@ func (m FieldMap) Edges() []*FieldMappingDescriptor {
 type FieldMappingDescriptor struct {
 	EntField          *gen.Field
 	PbFieldDescriptor *desc.FieldDescriptor
-	ToEntExpr         string
 	IsEdgeField       bool
 	IsIDField         bool
 }
@@ -116,19 +115,15 @@ func mapFields(entType *gen.Type, pbType *desc.MessageDescriptor) (FieldMap, err
 }
 
 func extractEntFieldByName(entType *gen.Type, name string) (*gen.Field, error) {
-	for _, fld := range allFields(entType) {
+	if name == entType.ID.Name {
+		return entType.ID, nil
+	}
+	for _, fld := range entType.Fields {
 		if fld.Name == name {
 			return fld, nil
 		}
 	}
 	return nil, fmt.Errorf("entproto: could not find find %q in %q", name, entType.Name)
-}
-
-func allFields(t *gen.Type) []*gen.Field {
-	var all []*gen.Field
-	all = append(all, t.ID)
-	all = append(all, t.Fields...)
-	return all
 }
 
 func ExtractTime(t *timestamppb.Timestamp) time.Time {

--- a/entproto/fieldmap.go
+++ b/entproto/fieldmap.go
@@ -1,0 +1,136 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entproto
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"entgo.io/ent/entc/gen"
+	"github.com/jhump/protoreflect/desc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// FieldMap returns a FieldMap containing descriptors of all of the mappings between the ent schema field
+// and the protobuf message's field descriptors.
+func (a *Adapter) FieldMap(schemaName string) (FieldMap, error) {
+	bt, err := extractGenTypeByName(a.graph, schemaName)
+	if err != nil {
+		return nil, err
+	}
+	md, err := a.GetMessageDescriptor(schemaName)
+	if err != nil {
+		return nil, err
+	}
+	return mapFields(bt, md)
+}
+
+// FieldMap contains a mapping between the field's name in the ent schema and a FieldMappingDescriptor
+type FieldMap map[string]*FieldMappingDescriptor
+
+// Fields returns the FieldMappingDescriptor for all of the fields of the schema.
+func (m FieldMap) Fields() []*FieldMappingDescriptor {
+	var out []*FieldMappingDescriptor
+	for _, f := range m {
+		if !f.IsEdgeField {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ID returns the FieldMappingDescriptor for the ID field of the schema.
+func (m FieldMap) ID() *FieldMappingDescriptor {
+	for _, f := range m {
+		if f.IsIDField {
+			return f
+		}
+	}
+	return nil
+}
+
+// Edges returns the FieldMappingDescriptor for all of the edge fields of the schema.
+func (m FieldMap) Edges() []*FieldMappingDescriptor {
+	var out []*FieldMappingDescriptor
+	for _, f := range m {
+		if f.IsEdgeField {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// FieldMappingDescriptor describes the mapping from a protobuf field descriptor to an ent Schema field
+type FieldMappingDescriptor struct {
+	EntField          *gen.Field
+	PbFieldDescriptor *desc.FieldDescriptor
+	ToEntExpr         string
+	IsEdgeField       bool
+	IsIDField         bool
+}
+
+func (d *FieldMappingDescriptor) PbStructField() string {
+	return strings.Title(camel(d.PbFieldDescriptor.GetName()))
+}
+
+func mapFields(entType *gen.Type, pbType *desc.MessageDescriptor) (FieldMap, error) {
+	m := make(map[string]*FieldMappingDescriptor)
+	for _, fld := range pbType.GetFields() {
+		isID := pascal(fld.GetName()) == pascal(entType.ID.Name)
+		var isEdge bool
+		for _, edg := range entType.Edges {
+			if fld.GetName() == edg.Name {
+				isEdge = true
+				break
+			}
+		}
+		var ef *gen.Field
+		if !isEdge {
+			enf, err := extractEntFieldByName(entType, fld.GetName())
+			if err != nil {
+				return nil, err
+			}
+			ef = enf
+		}
+		m[fld.GetName()] = &FieldMappingDescriptor{
+			PbFieldDescriptor: fld,
+			IsIDField:         isID,
+			IsEdgeField:       isEdge,
+			EntField:          ef,
+		}
+	}
+	return m, nil
+}
+
+func extractEntFieldByName(entType *gen.Type, name string) (*gen.Field, error) {
+	for _, fld := range allFields(entType) {
+		if fld.Name == name {
+			return fld, nil
+		}
+	}
+	return nil, fmt.Errorf("entproto: could not find find %q in %q", name, entType.Name)
+}
+
+func allFields(t *gen.Type) []*gen.Field {
+	var all []*gen.Field
+	all = append(all, t.ID)
+	all = append(all, t.Fields...)
+	return all
+}
+
+func ExtractTime(t *timestamppb.Timestamp) time.Time {
+	return t.AsTime()
+}

--- a/entproto/format.go
+++ b/entproto/format.go
@@ -19,4 +19,5 @@ import "entgo.io/ent/entc/gen"
 var (
 	snake  = gen.Funcs["snake"].(func(string) string)
 	pascal = gen.Funcs["pascal"].(func(string) string)
+	camel  = gen.Funcs["camel"].(func(string) string)
 )

--- a/entproto/internal/entprototest/fieldmapper_test.go
+++ b/entproto/internal/entprototest/fieldmapper_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entprototest
+
+func (suite *AdapterTestSuite) TestFieldMap() {
+	mp, err := suite.adapter.FieldMap("User")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(mp)
+
+	userName, ok := mp["user_name"]
+	suite.Require().True(ok)
+	suite.Assert().False(userName.IsIDField)
+	suite.Assert().False(userName.IsEdgeField)
+	suite.Assert().NotNil(userName.EntField)
+	suite.Assert().NotNil(userName.PbFieldDescriptor)
+	suite.Assert().NotNil(userName.PbFieldDescriptor)
+	suite.Assert().NoError(err)
+	suite.Assert().EqualValues("UserName", userName.PbStructField())
+
+	id, ok := mp["id"]
+	suite.Require().True(ok)
+	suite.Assert().True(id.IsIDField)
+	suite.Assert().False(id.IsEdgeField)
+	suite.Assert().EqualValues("Id", id.PbStructField())
+}

--- a/entproto/internal/entprototest/fieldmapper_test.go
+++ b/entproto/internal/entprototest/fieldmapper_test.go
@@ -25,8 +25,6 @@ func (suite *AdapterTestSuite) TestFieldMap() {
 	suite.Assert().False(userName.IsEdgeField)
 	suite.Assert().NotNil(userName.EntField)
 	suite.Assert().NotNil(userName.PbFieldDescriptor)
-	suite.Assert().NotNil(userName.PbFieldDescriptor)
-	suite.Assert().NoError(err)
 	suite.Assert().EqualValues("UserName", userName.PbStructField())
 
 	id, ok := mp["id"]
@@ -34,4 +32,10 @@ func (suite *AdapterTestSuite) TestFieldMap() {
 	suite.Assert().True(id.IsIDField)
 	suite.Assert().False(id.IsEdgeField)
 	suite.Assert().EqualValues("Id", id.PbStructField())
+
+	blogPosts, ok := mp["blog_posts"]
+	suite.Require().True(ok)
+	suite.Assert().EqualValues("BlogPosts", blogPosts.PbStructField())
+	suite.Assert().False(blogPosts.IsIDField)
+	suite.Assert().True(blogPosts.IsEdgeField)
 }


### PR DESCRIPTION
used later in the gRPC codegen to easily describe the mapping between the ent.Schema fields and the proto desc.MessageDescriptor