### PR TITLE
Export TemplateFuncs

### DIFF
--- a/entgql/template.go
+++ b/entgql/template.go
@@ -53,6 +53,11 @@ var (
 		TransactionTemplate,
 		EdgeTemplate,
 	}
+
+	// TemplateFuncs contains the extra template functions used by entgql.
+	TemplateFuncs = template.FuncMap{
+		"filterNodes": filterNodes,
+	}
 )
 
 //go:generate go run github.com/go-bindata/go-bindata/go-bindata -o=internal/bindata.go -pkg=internal -modtime=1 ./template
@@ -61,9 +66,7 @@ func parse(path string) *gen.Template {
 	text := string(internal.MustAsset(path))
 	return gen.MustParse(gen.NewTemplate(path).
 		Funcs(gen.Funcs).
-		Funcs(template.FuncMap{
-			"filterNodes": filterNodes,
-		}).
+		Funcs(TemplateFuncs).
 		Parse(text))
 }
 


### PR DESCRIPTION
Export template funcs to that users can match the available functions in extensions

entgql_extensions.tmpl
```
{{ $gqlNodes := filterNodes $.Nodes }}
...
```

```go
         var entgql_extensions = ...
	gen.MustParse(gen.NewTemplate("entgql_extensions").
		Funcs(entgql.TemplateFuncs).
		Parse(entgql_extensions)),
```