### PR TITLE
feat: value scanner type support

### DIFF
--- a/entproto/cmd/protoc-gen-entgrpc/converter.go
+++ b/entproto/cmd/protoc-gen-entgrpc/converter.go
@@ -37,8 +37,14 @@ func (g *serviceGenerator) newConverter(fld *entproto.FieldMappingDescriptor) (*
 	out := &converter{}
 	pbd := fld.PbFieldDescriptor
 	switch pbd.GetType() {
+	case dpb.FieldDescriptorProto_TYPE_BYTES:
+		if fld.EntField.Type.Valuer() {
+			out.toProtoConstructor = protogen.GoImportPath("entgo.io/contrib/entproto/runtime").Ident("MustValueToBytes")
+		} else if err := basicTypeConversion(fld.PbFieldDescriptor, fld.EntField, out); err != nil {
+			return nil, err
+		}
 	case dpb.FieldDescriptorProto_TYPE_BOOL, dpb.FieldDescriptorProto_TYPE_STRING,
-		dpb.FieldDescriptorProto_TYPE_BYTES, dpb.FieldDescriptorProto_TYPE_INT32,
+		dpb.FieldDescriptorProto_TYPE_INT32,
 		dpb.FieldDescriptorProto_TYPE_INT64, dpb.FieldDescriptorProto_TYPE_UINT32,
 		dpb.FieldDescriptorProto_TYPE_UINT64:
 		if err := basicTypeConversion(fld.PbFieldDescriptor, fld.EntField, out); err != nil {

--- a/entproto/runtime/extract.go
+++ b/entproto/runtime/extract.go
@@ -15,6 +15,8 @@
 package runtime
 
 import (
+	"database/sql/driver"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -48,4 +50,18 @@ func MustBytesToUUID(b []byte) uuid.UUID {
 func ValidateUUID(b []byte) error {
 	_, err := uuid.FromBytes(b)
 	return err
+}
+
+func MustValueToBytes(in driver.Valuer) []byte {
+	v, err := in.Value()
+	if err != nil {
+		panic(fmt.Sprintf("entproto: cannot evaluate valuer: %v", err))
+	}
+
+	out, ok := v.([]byte)
+	if !ok {
+		panic("entproto: cannot evaluate valuer: type not bytes")
+	}
+
+	return out
 }


### PR DESCRIPTION
this is a proof of concept of how we can integrate valuer type conversion. we could do something similar on the scanner side. i wanted to open this sooner rather than later for feedback. if you agree with the approach, i can continue work on it to support all value scanner types.

one suggestion i would make is to remove the runtime panics and instead return an appropriate grpc error status when conversion fails (i.e. `InvalidArgument` on requests/`FailedPrecondition` on responses).