### PR TITLE
all: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Main repo already uses it, why does this one not? ent has had two releases already.