### PR TITLE
entoas: add annotation to support custom oas types

### DIFF
--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -70,7 +70,7 @@ func OperationPolicy(p Policy) OperationConfigOption {
 // Example returns an example annotation.
 func Example(v interface{}) Annotation { return Annotation{Example: v} }
 
-// OASType returns a OASType annotation.
+// OASType returns an OASType annotation.
 func OASType(t *spec.Type) Annotation { return Annotation{OASType: t} }
 
 // CreateOperation returns a create operation annotation.

--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"entgo.io/contrib/entoas/serialization"
+	"entgo.io/contrib/entoas/spec"
 	"entgo.io/ent/entc/gen"
 	"entgo.io/ent/schema"
 )
@@ -29,6 +30,8 @@ type (
 		Groups serialization.Groups
 		// OpenAPI Specification example value for a schema field.
 		Example interface{}
+		// OpenAPI Specification type to use for a schema field.
+		OASType *spec.Type
 		// Create has meta information about a creation operation.
 		Create OperationConfig
 		// Read has meta information about a read operation.
@@ -66,6 +69,9 @@ func OperationPolicy(p Policy) OperationConfigOption {
 
 // Example returns an example annotation.
 func Example(v interface{}) Annotation { return Annotation{Example: v} }
+
+// OASType returns a OASType annotation.
+func OASType(t *spec.Type) Annotation { return Annotation{OASType: t} }
 
 // CreateOperation returns a create operation annotation.
 func CreateOperation(opts ...OperationConfigOption) Annotation {
@@ -118,6 +124,9 @@ func (a Annotation) Merge(o schema.Annotation) schema.Annotation {
 	}
 	if ant.Example != nil {
 		a.Example = ant.Example
+	}
+	if ant.OASType != nil {
+		a.OASType = ant.OASType
 	}
 	a.Create.merge(ant.Create)
 	a.Read.merge(ant.Read)

--- a/entoas/annotation_test.go
+++ b/entoas/annotation_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"entgo.io/contrib/entoas/serialization"
+	"entgo.io/contrib/entoas/spec"
 	"entgo.io/ent/entc/gen"
 	"github.com/stretchr/testify/require"
 )
@@ -46,9 +47,14 @@ func TestAnnotation(t *testing.T) {
 	b := Example("example")
 	require.Equal(t, "example", b.Example)
 
-	a = a.Merge(b).(Annotation)
+	st := &spec.Type{Type: "string", Format: "binary"}
+	c := OASType(st)
+	require.Equal(t, st, c.OASType)
+
+	a = a.Merge(b).(Annotation).Merge(c).(Annotation)
 	ex := Annotation{
 		Example: "example",
+		OASType: st,
 		List: OperationConfig{
 			Groups: serialization.Groups{"list", "groups"},
 			Policy: PolicyExpose,

--- a/entoas/generator_test.go
+++ b/entoas/generator_test.go
@@ -15,9 +15,14 @@
 package entoas
 
 import (
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"entgo.io/contrib/entoas/spec"
+	"entgo.io/ent/dialect"
 	"entgo.io/ent/entc/gen"
 	"entgo.io/ent/entc/load"
 	entfield "entgo.io/ent/schema/field"
@@ -28,30 +33,47 @@ import (
 func TestOASType(t *testing.T) {
 	t.Parallel()
 	for d, ex := range map[*entfield.Descriptor]*spec.Type{
-		entfield.Bool("bool").Descriptor():           _bool,
-		entfield.Bool("bool").Descriptor():           _bool,
-		entfield.Time("time").Descriptor():           _dateTime,
-		entfield.UUID("uuid", uuid.Nil).Descriptor(): _string,
-		entfield.Bytes("bytes").Descriptor():         _empty,
-		entfield.Enum("enum").Descriptor():           _string,
-		entfield.String("string").Descriptor():       _string,
-		entfield.Int8("int8").Descriptor():           _int32,
-		entfield.Int16("int16").Descriptor():         _int32,
-		entfield.Int32("int32").Descriptor():         _int32,
-		entfield.Int("int").Descriptor():             _int32,
-		entfield.Int64("int64").Descriptor():         _int64,
-		entfield.Uint8("uint8").Descriptor():         _int32,
-		entfield.Uint16("uint16").Descriptor():       _int32,
-		entfield.Uint32("uint32").Descriptor():       _int32,
-		entfield.Uint("uint").Descriptor():           _int32,
-		entfield.Uint64("uint64").Descriptor():       _int64,
-		entfield.Float32("float32").Descriptor():     _float,
-		entfield.Float("float64").Descriptor():       _double,
+		// Numeric
+		entfield.Int("int").Descriptor():         _int32,
+		entfield.Int8("int8").Descriptor():       _int32,
+		entfield.Int16("int16").Descriptor():     _int32,
+		entfield.Int32("int32").Descriptor():     _int32,
+		entfield.Int64("int64").Descriptor():     _int64,
+		entfield.Uint("uint").Descriptor():       _int32,
+		entfield.Uint8("uint8").Descriptor():     _int32,
+		entfield.Uint16("uint16").Descriptor():   _int32,
+		entfield.Uint32("uint32").Descriptor():   _int32,
+		entfield.Uint64("uint64").Descriptor():   _int64,
+		entfield.Float32("float32").Descriptor(): _float,
+		entfield.Float("float64").Descriptor():   _double,
+		// Basic
+		entfield.String("string").Descriptor():                  _string,
+		entfield.Bool("bool").Descriptor():                      _bool,
+		entfield.UUID("uuid", uuid.Nil).Descriptor():            _string,
+		entfield.Time("time").Descriptor():                      _dateTime,
+		entfield.Text("text").Descriptor():                      _string,
+		entfield.Enum("state").Values("on", "off").Descriptor(): _string,
+		// List
+		entfield.Strings("strings").Descriptor(): arr(_string),
+		entfield.Ints("ints").Descriptor():       arr(_int32),
+		entfield.Floats("floats").Descriptor():   arr(_double),
+		entfield.Bytes("bytes").Descriptor():     _bytes,
+		// Custom
+		entfield.JSON("nicknames", []string{}).Descriptor(): arr(_string),
+		entfield.JSON("json_slice", []http.Dir{}).
+			Annotations(OASType(arr(_string))).Descriptor(): arr(_string),
+		entfield.JSON("json_obj", url.URL{}).
+			Annotations(OASType(_string)).Descriptor(): _string,
+		entfield.Other("other", &Link{}).
+			SchemaType(map[string]string{dialect.Postgres: "varchar"}).
+			Default(DefaultLink()).
+			Annotations(OASType(_string)).
+			Descriptor(): _string,
 	} {
 		t.Run(d.Name, func(t *testing.T) {
 			f, err := load.NewField(d)
 			require.NoError(t, err)
-			ac, err := oasType(&gen.Field{Type: f.Info})
+			ac, err := oasType(&gen.Field{Type: f.Info, Annotations: f.Annotations})
 			if ex == _empty {
 				require.Error(t, err)
 			} else {
@@ -70,3 +92,36 @@ func TestOperation_Title(t *testing.T) {
 	require.Equal(t, "Delete", OpDelete.Title())
 	require.Equal(t, "List", OpList.Title())
 }
+
+type Link struct {
+	*url.URL
+}
+
+func DefaultLink() *Link {
+	u, _ := url.Parse("127.0.0.1")
+	return &Link{URL: u}
+}
+
+// Scan implements the Scanner interface.
+func (l *Link) Scan(value interface{}) (err error) {
+	switch v := value.(type) {
+	case nil:
+	case []byte:
+		l.URL, err = url.Parse(string(v))
+	case string:
+		l.URL, err = url.Parse(v)
+	default:
+		err = fmt.Errorf("unexpected type %T", v)
+	}
+	return
+}
+
+// Value implements the driver Valuer interface.
+func (l Link) Value() (driver.Value, error) {
+	if l.URL == nil {
+		return nil, nil
+	}
+	return l.String(), nil
+}
+
+func arr(t *spec.Type) *spec.Type { return &spec.Type{Type: "array", Items: t} }


### PR DESCRIPTION
This PR adds an Annotation to create an OAS type to use for custom GoTypes. 