### PR TITLE
Update node.tmpl to not include unreachable code

### DIFF
--- a/entgql/internal/todo/ent/gql_node.go
+++ b/entgql/internal/todo/ent/gql_node.go
@@ -374,6 +374,7 @@ func (c *Client) noders(ctx context.Context, table string, ids []int) ([]Noder, 
 				*noder = node
 			}
 		}
+		return noders, nil
 	case todo.Table:
 		nodes, err := c.Todo.Query().
 			Where(todo.IDIn(ids...)).
@@ -387,10 +388,10 @@ func (c *Client) noders(ctx context.Context, table string, ids []int) ([]Noder, 
 				*noder = node
 			}
 		}
+		return noders, nil
 	default:
 		return nil, fmt.Errorf("cannot resolve noders from table %q: %w", table, errNodeInvalidID)
 	}
-	return noders, nil
 }
 
 type tables struct {

--- a/entgql/internal/todopulid/ent/gql_node.go
+++ b/entgql/internal/todopulid/ent/gql_node.go
@@ -369,6 +369,7 @@ func (c *Client) noders(ctx context.Context, table string, ids []pulid.ID) ([]No
 				*noder = node
 			}
 		}
+		return noders, nil
 	case todo.Table:
 		nodes, err := c.Todo.Query().
 			Where(todo.IDIn(ids...)).
@@ -382,8 +383,8 @@ func (c *Client) noders(ctx context.Context, table string, ids []pulid.ID) ([]No
 				*noder = node
 			}
 		}
+		return noders, nil
 	default:
 		return nil, fmt.Errorf("cannot resolve noders from table %q: %w", table, errNodeInvalidID)
 	}
-	return noders, nil
 }

--- a/entgql/internal/todouuid/ent/gql_node.go
+++ b/entgql/internal/todouuid/ent/gql_node.go
@@ -369,6 +369,7 @@ func (c *Client) noders(ctx context.Context, table string, ids []uuid.UUID) ([]N
 				*noder = node
 			}
 		}
+		return noders, nil
 	case todo.Table:
 		nodes, err := c.Todo.Query().
 			Where(todo.IDIn(ids...)).
@@ -382,8 +383,8 @@ func (c *Client) noders(ctx context.Context, table string, ids []uuid.UUID) ([]N
 				*noder = node
 			}
 		}
+		return noders, nil
 	default:
 		return nil, fmt.Errorf("cannot resolve noders from table %q: %w", table, errNodeInvalidID)
 	}
-	return noders, nil
 }

--- a/entgql/template/node.tmpl
+++ b/entgql/template/node.tmpl
@@ -287,11 +287,11 @@ func (c *Client) noders(ctx context.Context, table string, ids []{{ $idType }}) 
 					*noder = node
 				}
 			}
+			return noders, nil
 	{{- end }}
 	default:
 		return nil, fmt.Errorf("cannot resolve noders from table %q: %w", table, errNodeInvalidID)
 	}
-	return noders, nil
 }
 
 {{ if $idType.Numeric }}


### PR DESCRIPTION
Hello, I'm facing a problem with `go vet` about this line:

https://github.com/ent/contrib/blob/0e3a610c60241fa56a27d1a423cea4c904f12dfd/entgql/template/node.tmpl#L293-L295

`pkg/ent/node.go:190:2: unreachable code`

![image](https://user-images.githubusercontent.com/1251151/144695406-5693c79d-4722-47c1-b910-01be6c3f4ee6.png)


As I understand it, it is not necessary as the `default` works as a catch all, doesn't?