### PR TITLE
entoas: export EdgeViewName to make it accessible for implementation …

### DIFF
--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -307,7 +307,7 @@ func createEdgeOp(spec *ogen.Spec, n *gen.Type, e *gen.Edge) (*ogen.Operation, e
 	if err != nil {
 		return nil, err
 	}
-	vn, err := edgeViewName(n, e, OpCreate)
+	vn, err := EdgeViewName(n, e, OpCreate)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func readEdgeOp(spec *ogen.Spec, n *gen.Type, e *gen.Edge) (*ogen.Operation, err
 	if err != nil {
 		return nil, err
 	}
-	vn, err := edgeViewName(n, e, OpRead)
+	vn, err := EdgeViewName(n, e, OpRead)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +537,7 @@ func listEdgeOp(spec *ogen.Spec, n *gen.Type, e *gen.Edge) (*ogen.Operation, err
 	if err != nil {
 		return nil, err
 	}
-	vn, err := edgeViewName(n, e, OpList)
+	vn, err := EdgeViewName(n, e, OpList)
 	if err != nil {
 		return nil, err
 	}

--- a/entoas/view.go
+++ b/entoas/view.go
@@ -94,7 +94,7 @@ func Views(g *gen.Graph) (map[string]*View, error) {
 				if err != nil {
 					return nil, err
 				}
-				vn, err := edgeViewName(n, e, op)
+				vn, err := EdgeViewName(n, e, op)
 				if err != nil {
 					return nil, err
 				}
@@ -224,8 +224,8 @@ func ViewName(n *gen.Type, op Operation) (string, error) { // TODO(masseelch): A
 	return n.Name + op.Title(), nil
 }
 
-// edgeViewName returns the name for a view for a given 2nd leve operation on a gen.Edge.
-func edgeViewName(n *gen.Type, e *gen.Edge, op Operation) (string, error) { // TODO(masseelch): Add tests for collisions
+// EdgeViewName returns the name for a view for a given 2nd leve operation on a gen.Edge.
+func EdgeViewName(n *gen.Type, e *gen.Edge, op Operation) (string, error) { // TODO(masseelch): Add tests for collisions
 	cfg, err := GetConfig(n.Config)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
…generators

This PR exports the formerly named function `edgeViewName` by renaming it to `EdgeViewName`. Any implementation generators should then be able to get the correct names for code generation.