### PR TITLE
entoas: add 404 response to create-sub operation

### DIFF
--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -327,6 +327,7 @@ func createEdgeOp(spec *ogen.Spec, n *gen.Type, e *gen.Edge) (*ogen.Operation, e
 		AddNamedResponses(
 			spec.RefResponse(strconv.Itoa(http.StatusBadRequest)),
 			spec.RefResponse(strconv.Itoa(http.StatusConflict)),
+			spec.RefResponse(strconv.Itoa(http.StatusNotFound)),
 			spec.RefResponse(strconv.Itoa(http.StatusInternalServerError)),
 		)
 	return op, nil

--- a/entoas/internal/cycle/openapi.json
+++ b/entoas/internal/cycle/openapi.json
@@ -431,6 +431,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -576,6 +579,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"
@@ -723,6 +729,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -869,6 +878,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -993,6 +1005,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"

--- a/entoas/internal/pets/openapi.json
+++ b/entoas/internal/pets/openapi.json
@@ -401,6 +401,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -823,6 +826,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -972,6 +978,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -1085,6 +1094,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"
@@ -1532,6 +1544,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"

--- a/entoas/internal/simple/openapi.json
+++ b/entoas/internal/simple/openapi.json
@@ -401,6 +401,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -823,6 +826,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -972,6 +978,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -1085,6 +1094,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"
@@ -1532,6 +1544,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"


### PR DESCRIPTION
This PR adds a 404 response to the create operations on sub routes since the parent might not exist. Example: 

`POST /pets/1/owner` <- Pet with ID 1 might not exist. 404 is needed.