### PR TITLE
feat(entproto): support for named proto messages

### DIFF
--- a/entproto/field.go
+++ b/entproto/field.go
@@ -36,9 +36,10 @@ func Field(num int, options ...FieldOption) schema.Annotation {
 }
 
 type pbfield struct {
-	Number   int
-	Type     descriptorpb.FieldDescriptorProto_Type
-	TypeName string
+	Number    int
+	Type      descriptorpb.FieldDescriptorProto_Type
+	TypeName  string
+	FieldName string
 }
 
 func (f pbfield) Name() string {
@@ -63,6 +64,13 @@ func Type(typ descriptorpb.FieldDescriptorProto_Type) FieldOption {
 func TypeName(n string) FieldOption {
 	return func(p *pbfield) {
 		p.TypeName = n
+	}
+}
+
+// FieldName sets the pb descriptors type name, needed if the Type attribute is TYPE_ENUM or TYPE_MESSAGE.
+func FieldName(n string) FieldOption {
+	return func(p *pbfield) {
+		p.FieldName = n
 	}
 }
 

--- a/entproto/fieldgroup.go
+++ b/entproto/fieldgroup.go
@@ -1,0 +1,104 @@
+package entproto
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/entc/gen"
+	"entgo.io/ent/schema"
+	"github.com/mitchellh/mapstructure"
+)
+
+type FieldGroup struct {
+	Name   string
+	Fields []ent.Field
+}
+
+// type FieldGroups []FieldGroup
+
+// func (fg FieldGroups) Fields() []ent.Field {
+// 	fields := []ent.Field{}
+// 	for _, g := range fg {
+// 		fields = append(fields, g.Fields...)
+// 	}
+// 	return fields
+// }
+
+func (fg FieldGroups) ByName(names ...string) FieldGroups {
+	result := FieldGroups{
+		groups: []*FieldGroup{},
+		Names:  []string{},
+	}
+	for _, g := range fg.groups {
+		for _, name := range names {
+			if g.Name == name {
+				result.groups = append(result.groups, g)
+				result.Names = append(result.Names, g.Name)
+			}
+		}
+	}
+	return result
+}
+
+type FieldGroups struct {
+	groups []*FieldGroup
+	Names  []string
+}
+
+func Groups() *FieldGroups {
+	return &FieldGroups{
+		groups: []*FieldGroup{},
+		Names:  []string{},
+	}
+}
+
+func (g *FieldGroups) Group(name string, builder func(*FieldGroup)) *FieldGroups {
+	f := &FieldGroup{
+		Name: name,
+	}
+	builder(f)
+
+	// Append the annotations
+	for _, f := range f.Fields {
+		d := f.Descriptor()
+		d.Annotations = append(d.Annotations, GroupName(name))
+	}
+
+	g.groups = append(g.groups, f)
+	g.Names = append(g.Names, name)
+
+	return g
+}
+
+func (fg FieldGroups) Fields() []ent.Field {
+	fields := []ent.Field{}
+	for _, g := range fg.groups {
+		fields = append(fields, g.Fields...)
+	}
+	return fields
+}
+
+const GroupNameAnnotation = "ProtoFieldGroupName"
+
+func GroupName(name string) schema.Annotation {
+	f := &pbgroupName{GroupName: name}
+	return f
+}
+
+type pbgroupName struct {
+	GroupName string
+}
+
+func (f pbgroupName) Name() string {
+	return GroupNameAnnotation
+}
+
+func extractGroupNameAnnotation(sch *gen.Field) *pbgroupName {
+	annot, ok := sch.Annotations[GroupNameAnnotation]
+	if !ok {
+		return nil
+	}
+
+	var groupName pbgroupName
+	mapstructure.Decode(annot, &groupName)
+
+	return &groupName
+}

--- a/entproto/message.go
+++ b/entproto/message.go
@@ -33,6 +33,7 @@ func Message(opts ...MessageOption) schema.Annotation {
 		Generate: true,
 		Package:  "entpb",
 	}
+	m.SkipID = true
 	for _, apply := range opts {
 		apply(&m)
 	}
@@ -55,9 +56,22 @@ func PackageName(pkg string) MessageOption {
 	}
 }
 
+// // IncludeID allows to control whether the id field will be included in the proto message or not
+// func SkipID(include bool) MessageOption {
+// 	return func(msg *message) {
+// 		msg.IncludeID = include
+// 	}
+// }
+
+type messageProto struct {
+	SkipID bool
+}
+
 type message struct {
-	Generate bool
-	Package  string
+	messageProto
+	Generate      bool
+	Package       string
+	NamedMessages []*namedMessage
 }
 
 func (m message) Name() string {

--- a/entproto/named_messages.go
+++ b/entproto/named_messages.go
@@ -1,0 +1,77 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entproto
+
+import "google.golang.org/protobuf/types/descriptorpb"
+
+const (
+	TypeBool   = descriptorpb.FieldDescriptorProto_TYPE_BOOL
+	TypeString = descriptorpb.FieldDescriptorProto_TYPE_STRING
+)
+
+// Message annotates an ent.Schema to specify that protobuf message generation is required for it.
+func NamedMessages(messages ...*namedMessage) MessageOption {
+	return func(msg *message) {
+		msg.NamedMessages = append(msg.NamedMessages, messages...)
+	}
+}
+
+func NamedMessage(name string) *namedMessage {
+	return &namedMessage{
+		ProtoMessageOptions: protoMessageOptions{},
+		Name:                name,
+	}
+}
+
+type namedMessage struct {
+	ProtoMessageOptions protoMessageOptions
+	Name                string
+	Groups              FieldGroups
+	ExtraFields         []pbfield
+}
+
+func (nm *namedMessage) WithGroups(groups FieldGroups) *namedMessage {
+	nm.Groups = groups
+	return nm
+}
+
+func (nm *namedMessage) WithSkipID(skip bool) *namedMessage {
+	nm.ProtoMessageOptions.SkipID = skip
+	return nm
+}
+
+func (nm *namedMessage) WithExtraFields(fields ...*extraField) *namedMessage {
+	nm.ProtoMessageOptions.ExtraFields = append(nm.ProtoMessageOptions.ExtraFields, fields...)
+	return nm
+}
+
+func ExtraField(name string, number int) *extraField {
+	return &extraField{
+		Name: name,
+		Descriptor: pbfield{
+			Number: number,
+		},
+	}
+}
+
+func (ef *extraField) WithType(t descriptorpb.FieldDescriptorProto_Type) *extraField {
+	ef.Descriptor.Type = t
+	return ef
+}
+
+func (ef *extraField) WithTypeName(name string) *extraField {
+	ef.Descriptor.TypeName = name
+	return ef
+}


### PR DESCRIPTION
Hello, I would like to get your feedback on my proposal to add support for more granular control over proto message generated by the entproto package.  

The motivation here is to have full control over proto messages that are being generated based on ent schema. The contrib package is great but GRPC service generated out of it doesn't yet provide enough extensibility. 

The proposal contains several features:
- Ability to specify a different names for fields to decouple from the DB layer. For example for a sake of compatibility with existing systems. 
- Named messages, a concept that allows creating multiple custom proto messages based on fields, edges, or fields groups, 
- Support for extra fields that will not have a counterpart in the database. To allow model more complex scenarios. JSONB etc. 
- Support for "field groups" that allow you to work with fields more efficiently in named messages. 
- Allow to not render the ID field

### The go schema definition

```
type Car struct {
	ent.Schema
}

func (c Car) Annotations() []schema.Annotation {
	return []schema.Annotation{
		entproto.Message(
			entproto.NamedMessages(
				entproto.NamedMessage("CarUpdate").
					WithGroups(
						c.Groups().ByName("common", "dates"),
					).
					WithExtraFields(
						entproto.ExtraField("extra_1", 4).WithType(entproto.TypeBool),
						entproto.ExtraField("extra_2", 5).WithType(entproto.TypeString),
					).
					WithSkipID(true),
				entproto.NamedMessage("CarUpdateDates").WithGroups(
					c.Groups().ByName("dates"),
				).WithSkipID(true),
			),
		),
	}
}

func (Car) Groups() *entproto.FieldGroups {
	return entproto.Groups().
		Group("common", func(fg *entproto.FieldGroup) {
			fg.Fields = []ent.Field{
				field.String("model").Annotations(entproto.Field(2)),
			}
		}).
		Group("dates", func(fg *entproto.FieldGroup) {
			fg.Fields = []ent.Field{
				field.Time("registered_at").Annotations(entproto.Field(3, entproto.FieldName("RegisteredAt"))),
			}
		})
}

// Fields of the Car.
func (c Car) Fields() []ent.Field {
	return c.Groups().Fields() // ByName("common", "dates").Fields()
}
```


### Generated proto
```
// Code generated by entproto. DO NOT EDIT.
syntax = "proto3";

package entpb;

import "google/protobuf/timestamp.proto";

option go_package = "outreach.io/enttest/ent/proto/entpb";

message Car {
  int32 id = 1;

  string model = 2;

  google.protobuf.Timestamp RegisteredAt = 3;
}

message CarUpdate {
  string model = 2;

  google.protobuf.Timestamp RegisteredAt = 3;

  bool extra_1 = 4;

  string extra_2 = 5;
}

message CarUpdateDates {
  google.protobuf.Timestamp RegisteredAt = 3;
}
```


