### PR TITLE
entgql: enable bind by default

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -50,7 +50,10 @@ func OrderField(name string) Annotation {
 // No-op function to avoid breaking the existing schema.
 // You can safely remove this function from your scheme.
 // To disable Bind, use BindDisabled()
-func Bind() Annotation {
+func Bind(binds ...bool) Annotation {
+	if len(binds) > 0 {
+		return Annotation{BindDisabled: !binds[0]}
+	}
 	return Annotation{}
 }
 

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -24,9 +24,9 @@ import (
 type Annotation struct {
 	// OrderField is the ordering field as defined in graphql schema.
 	OrderField string `json:"OrderField,omitempty"`
-	// Bind implies the edge field name in graphql schema
+	// BindDisabled implies the edge field name in graphql schema
 	// is equivalent to the name used in ent schema.
-	Bind bool `json:"Bind,omitempty"`
+	BindDisabled bool `json:"BindDisabled,omitempty"`
 	// Mapping is the edge field names as defined in graphql schema.
 	Mapping []string `json:"Mapping,omitempty"`
 	// Type is the underlying GraphQL type name (e.g. Boolean).
@@ -46,8 +46,17 @@ func OrderField(name string) Annotation {
 }
 
 // Bind returns a binding annotation.
+//
+// No-op function to avoid breaking the existing schema.
+// You can safely remove this function from your scheme.
+// To disable Bind, use BindDisabled()
 func Bind() Annotation {
-	return Annotation{Bind: true}
+	return Annotation{}
+}
+
+// BindDisabled returns a disabled binding annotation.
+func BindDisabled() Annotation {
+	return Annotation{BindDisabled: true}
 }
 
 // MapsTo returns a mapping annotation.
@@ -81,8 +90,8 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	if ant.OrderField != "" {
 		a.OrderField = ant.OrderField
 	}
-	if ant.Bind {
-		a.Bind = true
+	if ant.BindDisabled {
+		a.BindDisabled = true
 	}
 	if len(ant.Mapping) != 0 {
 		a.Mapping = ant.Mapping

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -24,8 +24,10 @@ import (
 type Annotation struct {
 	// OrderField is the ordering field as defined in graphql schema.
 	OrderField string `json:"OrderField,omitempty"`
-	// Unbind implies the edge field name in graphql schema
-	// isn't equivalent to the name used in ent schema.
+	// Unbind implies the edge field name in GraphQL schema is not equivalent
+	// to the name used in ent schema. That means, by default, edges with this
+	// annotation will not be eager-loaded on Paginate calls. See the `MapsTo`
+	// option in order to load edges be different name mapping.
 	Unbind bool `json:"Unbind,omitempty"`
 	// Mapping is the edge field names as defined in graphql schema.
 	Mapping []string `json:"Mapping,omitempty"`
@@ -49,12 +51,18 @@ func OrderField(name string) Annotation {
 //
 // No-op function to avoid breaking the existing schema.
 // You can safely remove this function from your scheme.
-// To disable Bind, use Unbind()
+//
+// Deprecated: the Bind option predates the Unbind option, and it is planned
+// to be removed in future versions. Users should not use this annotation as it
+// is a no-op call, or use `Unbind` in order to disable `Bind`.
 func Bind() Annotation {
 	return Annotation{}
 }
 
-// Unbind returns a unbinding annotation.
+// Unbind implies the edge field name in GraphQL schema is not equivalent
+// to the name used in ent schema. That means, by default, edges with this
+// annotation will not be eager-loaded on Paginate calls. See the `MapsTo`
+// option in order to load edges be different name mapping.
 func Unbind() Annotation {
 	return Annotation{Unbind: true}
 }
@@ -63,7 +71,7 @@ func Unbind() Annotation {
 func MapsTo(names ...string) Annotation {
 	return Annotation{
 		Mapping: names,
-		Unbind:  true, // Unbind because it cant be used with mapping names
+		Unbind:  true, // Unbind because it cant be used with mapping names.
 	}
 }
 

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -24,9 +24,9 @@ import (
 type Annotation struct {
 	// OrderField is the ordering field as defined in graphql schema.
 	OrderField string `json:"OrderField,omitempty"`
-	// BindDisabled implies the edge field name in graphql schema
+	// Unbind implies the edge field name in graphql schema
 	// isn't equivalent to the name used in ent schema.
-	BindDisabled bool `json:"BindDisabled,omitempty"`
+	Unbind bool `json:"Unbind,omitempty"`
 	// Mapping is the edge field names as defined in graphql schema.
 	Mapping []string `json:"Mapping,omitempty"`
 	// Type is the underlying GraphQL type name (e.g. Boolean).
@@ -49,25 +49,21 @@ func OrderField(name string) Annotation {
 //
 // No-op function to avoid breaking the existing schema.
 // You can safely remove this function from your scheme.
-// To disable Bind, use BindDisabled()
-func Bind(binds ...bool) Annotation {
-	if len(binds) > 0 && !binds[0] {
-		return Annotation{BindDisabled: true}
-	}
+// To disable Bind, use Unbind()
+func Bind() Annotation {
 	return Annotation{}
 }
 
-// BindDisabled returns a disabled binding annotation.
-func BindDisabled() Annotation {
-	return Annotation{BindDisabled: true}
+// Unbind returns a unbinding annotation.
+func Unbind() Annotation {
+	return Annotation{Unbind: true}
 }
 
 // MapsTo returns a mapping annotation.
 func MapsTo(names ...string) Annotation {
 	return Annotation{
 		Mapping: names,
-		// Disable bind because it cant be used with mapping names
-		BindDisabled: true,
+		Unbind:  true, // Unbind because it cant be used with mapping names
 	}
 }
 
@@ -97,8 +93,8 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	if ant.OrderField != "" {
 		a.OrderField = ant.OrderField
 	}
-	if ant.BindDisabled {
-		a.BindDisabled = true
+	if ant.Unbind {
+		a.Unbind = true
 	}
 	if len(ant.Mapping) != 0 {
 		a.Mapping = ant.Mapping

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -25,7 +25,7 @@ type Annotation struct {
 	// OrderField is the ordering field as defined in graphql schema.
 	OrderField string `json:"OrderField,omitempty"`
 	// BindDisabled implies the edge field name in graphql schema
-	// is equivalent to the name used in ent schema.
+	// isn't equivalent to the name used in ent schema.
 	BindDisabled bool `json:"BindDisabled,omitempty"`
 	// Mapping is the edge field names as defined in graphql schema.
 	Mapping []string `json:"Mapping,omitempty"`

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -51,8 +51,8 @@ func OrderField(name string) Annotation {
 // You can safely remove this function from your scheme.
 // To disable Bind, use BindDisabled()
 func Bind(binds ...bool) Annotation {
-	if len(binds) > 0 {
-		return Annotation{BindDisabled: !binds[0]}
+	if len(binds) > 0 && !binds[0] {
+		return Annotation{BindDisabled: true}
 	}
 	return Annotation{}
 }

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -61,7 +61,11 @@ func BindDisabled() Annotation {
 
 // MapsTo returns a mapping annotation.
 func MapsTo(names ...string) Annotation {
-	return Annotation{Mapping: names}
+	return Annotation{
+		Mapping: names,
+		// Disable bind because it cant be used with mapping names
+		BindDisabled: true,
+	}
 }
 
 // Type returns a type mapping annotation.

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -27,14 +27,14 @@ func TestAnnotation(t *testing.T) {
 	require.Equal(t, "foo", annotation.OrderField)
 
 	annotation = entgql.Bind()
-	require.False(t, annotation.BindDisabled)
-	annotation = entgql.BindDisabled()
-	require.True(t, annotation.BindDisabled)
+	require.False(t, annotation.Unbind)
+	annotation = entgql.Unbind()
+	require.True(t, annotation.Unbind)
 	require.Empty(t, annotation.Mapping)
 
 	names := []string{"foo", "bar", "baz"}
 	annotation = entgql.MapsTo(names...)
-	require.True(t, annotation.BindDisabled)
+	require.True(t, annotation.Unbind)
 	require.ElementsMatch(t, names, annotation.Mapping)
 }
 
@@ -45,17 +45,17 @@ func TestAnnotationDecode(t *testing.T) {
 	require.Equal(t, ann, &entgql.Annotation{})
 	ann = &entgql.Annotation{}
 	err = ann.Decode(map[string]interface{}{
-		"OrderField":   "NAME",
-		"BindDisabled": true,
-		"Mapping":      []string{"f1", "f2"},
-		"Skip":         true,
+		"OrderField": "NAME",
+		"Unbind":     true,
+		"Mapping":    []string{"f1", "f2"},
+		"Skip":       true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, ann, &entgql.Annotation{
-		OrderField:   "NAME",
-		BindDisabled: true,
-		Mapping:      []string{"f1", "f2"},
-		Skip:         true,
+		OrderField: "NAME",
+		Unbind:     true,
+		Mapping:    []string{"f1", "f2"},
+		Skip:       true,
 	})
 	err = ann.Decode("invalid")
 	require.NotNil(t, err)

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -34,7 +34,7 @@ func TestAnnotation(t *testing.T) {
 
 	names := []string{"foo", "bar", "baz"}
 	annotation = entgql.MapsTo(names...)
-	require.False(t, annotation.BindDisabled)
+	require.True(t, annotation.BindDisabled)
 	require.ElementsMatch(t, names, annotation.Mapping)
 }
 

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -45,10 +45,10 @@ func TestAnnotationDecode(t *testing.T) {
 	require.Equal(t, ann, &entgql.Annotation{})
 	ann = &entgql.Annotation{}
 	err = ann.Decode(map[string]interface{}{
-		"OrderField": "NAME",
-		"Bind":       true,
-		"Mapping":    []string{"f1", "f2"},
-		"Skip":       true,
+		"OrderField":   "NAME",
+		"BindDisabled": true,
+		"Mapping":      []string{"f1", "f2"},
+		"Skip":         true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, ann, &entgql.Annotation{

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -27,12 +27,14 @@ func TestAnnotation(t *testing.T) {
 	require.Equal(t, "foo", annotation.OrderField)
 
 	annotation = entgql.Bind()
-	require.True(t, annotation.Bind)
+	require.False(t, annotation.BindDisabled)
+	annotation = entgql.BindDisabled()
+	require.True(t, annotation.BindDisabled)
 	require.Empty(t, annotation.Mapping)
 
 	names := []string{"foo", "bar", "baz"}
 	annotation = entgql.MapsTo(names...)
-	require.False(t, annotation.Bind)
+	require.False(t, annotation.BindDisabled)
 	require.ElementsMatch(t, names, annotation.Mapping)
 }
 
@@ -50,10 +52,10 @@ func TestAnnotationDecode(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, ann, &entgql.Annotation{
-		OrderField: "NAME",
-		Bind:       true,
-		Mapping:    []string{"f1", "f2"},
-		Skip:       true,
+		OrderField:   "NAME",
+		BindDisabled: true,
+		Mapping:      []string{"f1", "f2"},
+		Skip:         true,
 	})
 	err = ann.Decode("invalid")
 	require.NotNil(t, err)

--- a/entgql/internal/todo/ent/schema/category.go
+++ b/entgql/internal/todo/ent/schema/category.go
@@ -69,6 +69,7 @@ func (Category) Fields() []ent.Field {
 // Edges of the Category.
 func (Category) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("todos", Todo.Type),
+		edge.To("todos", Todo.Type).
+			Annotations(entgql.BindDisabled()),
 	}
 }

--- a/entgql/internal/todo/ent/schema/category.go
+++ b/entgql/internal/todo/ent/schema/category.go
@@ -70,6 +70,6 @@ func (Category) Fields() []ent.Field {
 func (Category) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("todos", Todo.Type).
-			Annotations(entgql.BindDisabled()),
+			Annotations(entgql.Unbind()),
 	}
 }

--- a/entgql/internal/todo/ent/schema/todo.go
+++ b/entgql/internal/todo/ent/schema/todo.go
@@ -69,7 +69,9 @@ func (Todo) Edges() []ent.Edge {
 			Annotations(entgql.Bind()).
 			Unique(),
 		edge.From("category", Category.Type).
+			Annotations(entgql.BindDisabled()).
 			Ref("todos").
+			Annotations(entgql.BindDisabled()).
 			Unique(),
 		edge.To("secret", VerySecret.Type).
 			Unique(),

--- a/entgql/internal/todo/ent/schema/todo.go
+++ b/entgql/internal/todo/ent/schema/todo.go
@@ -69,9 +69,9 @@ func (Todo) Edges() []ent.Edge {
 			Annotations(entgql.Bind()).
 			Unique(),
 		edge.From("category", Category.Type).
-			Annotations(entgql.Bind(false)).
+			Annotations(entgql.Unbind()).
 			Ref("todos").
-			Annotations(entgql.Bind(false)).
+			Annotations(entgql.Unbind()).
 			Unique(),
 		edge.To("secret", VerySecret.Type).
 			Unique(),

--- a/entgql/internal/todo/ent/schema/todo.go
+++ b/entgql/internal/todo/ent/schema/todo.go
@@ -69,9 +69,9 @@ func (Todo) Edges() []ent.Edge {
 			Annotations(entgql.Bind()).
 			Unique(),
 		edge.From("category", Category.Type).
-			Annotations(entgql.BindDisabled()).
+			Annotations(entgql.Bind(false)).
 			Ref("todos").
-			Annotations(entgql.BindDisabled()).
+			Annotations(entgql.Bind(false)).
 			Unique(),
 		edge.To("secret", VerySecret.Type).
 			Unique(),

--- a/entgql/internal/todo/ent/schema/todo.go
+++ b/entgql/internal/todo/ent/schema/todo.go
@@ -64,8 +64,10 @@ func (Todo) Fields() []ent.Field {
 func (Todo) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("children", Todo.Type).
+			//nolint SA1019 we keep this as the example.
 			Annotations(entgql.Bind()).
 			From("parent").
+			//nolint SA1019 we keep this as the example.
 			Annotations(entgql.Bind()).
 			Unique(),
 		edge.From("category", Category.Type).

--- a/entgql/internal/todofed/ent/gql_collection.go
+++ b/entgql/internal/todofed/ent/gql_collection.go
@@ -31,6 +31,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 }
 
 func (c *CategoryQuery) collectField(ctx *graphql.OperationContext, field graphql.CollectedField, satisfies ...string) *CategoryQuery {
+	for _, field := range graphql.CollectFields(ctx, field.Selections, satisfies) {
+		switch field.Name {
+		case "todos":
+			c = c.WithTodos(func(query *TodoQuery) {
+				query.collectField(ctx, field)
+			})
+		}
+	}
 	return c
 }
 
@@ -45,6 +53,10 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) *Tod
 func (t *TodoQuery) collectField(ctx *graphql.OperationContext, field graphql.CollectedField, satisfies ...string) *TodoQuery {
 	for _, field := range graphql.CollectFields(ctx, field.Selections, satisfies) {
 		switch field.Name {
+		case "category":
+			t = t.WithCategory(func(query *CategoryQuery) {
+				query.collectField(ctx, field)
+			})
 		case "children":
 			t = t.WithChildren(func(query *TodoQuery) {
 				query.collectField(ctx, field)

--- a/entgql/internal/todofed/ent/schema/todo.go
+++ b/entgql/internal/todofed/ent/schema/todo.go
@@ -64,8 +64,10 @@ func (Todo) Fields() []ent.Field {
 func (Todo) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("children", Todo.Type).
+			//nolint SA1019 we keep this as the example.
 			Annotations(entgql.Bind()).
 			From("parent").
+			//nolint SA1019 we keep this as the example.
 			Annotations(entgql.Bind()).
 			Unique(),
 		edge.From("category", Category.Type).

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -99,7 +99,7 @@ func fieldCollections(edges []*gen.Edge) (map[string]fieldCollection, error) {
 				return nil, err
 			}
 
-			if ant.BindDisabled {
+			if ant.Unbind {
 				delete(result, e.Name)
 			}
 			if len(ant.Mapping) > 0 {

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -92,29 +92,26 @@ func fieldCollections(edges []*gen.Edge) (map[string]fieldCollection, error) {
 			Name:    e.Type.Name,
 			Mapping: []string{e.Name},
 		}
-
 		ant := &Annotation{}
-		if e.Annotations != nil && e.Annotations[ant.Name()] != nil {
-			if err := ant.Decode(e.Annotations[ant.Name()]); err != nil {
-				return nil, err
+		if e.Annotations == nil || e.Annotations[ant.Name()] == nil {
+			continue
+		}
+		if err := ant.Decode(e.Annotations[ant.Name()]); err != nil {
+			return nil, err
+		}
+		if ant.Unbind {
+			delete(result, e.Name)
+		}
+		if len(ant.Mapping) > 0 {
+			if _, bind := result[e.Name]; bind {
+				return nil, errors.New("bind and mapping annotations are mutually exclusive")
 			}
-
-			if ant.Unbind {
-				delete(result, e.Name)
-			}
-			if len(ant.Mapping) > 0 {
-				if _, bind := result[e.Name]; bind {
-					return nil, errors.New("bind and mapping annotations are mutually exclusive")
-				}
-
-				result[e.Name] = fieldCollection{
-					Name:    e.Type.Name,
-					Mapping: ant.Mapping,
-				}
+			result[e.Name] = fieldCollection{
+				Name:    e.Type.Name,
+				Mapping: ant.Mapping,
 			}
 		}
 	}
-
 	return result, nil
 }
 

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -20,13 +20,15 @@ import (
 {{ $edges := dict }}
 {{ range $edge := filterEdges $node.Edges }}
 	{{ if $annotation := $edge.Annotations.EntGQL }}
-		{{ if $annotation.Bind }}
+		{{ if not $annotation.BindDisabled }}
 			{{ if $annotation.Mapping }}{{ fail "bind and mapping annotations are mutually exclusive" }}{{ end }}
 			{{ $edges = set $edges $edge.Name (list $edge.Type.Name (list $edge.Name)) }}
 		{{ end }}
 		{{ if $mapping := $annotation.Mapping }}
 			{{ $edges = set $edges $edge.Name (list $edge.Type.Name $mapping) }}
 		{{ end }}
+	{{ else }}
+		{{ $edges = set $edges $edge.Name (list $edge.Type.Name (list $edge.Name)) }}
 	{{ end }}
 {{ end }}
 

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -17,21 +17,6 @@ import (
 
 {{ range $node := filterNodes $.Nodes }}
 
-{{ $edges := dict }}
-{{ range $edge := filterEdges $node.Edges }}
-	{{ if $annotation := $edge.Annotations.EntGQL }}
-		{{ if not $annotation.BindDisabled }}
-			{{ if $annotation.Mapping }}{{ fail "bind and mapping annotations are mutually exclusive" }}{{ end }}
-			{{ $edges = set $edges $edge.Name (list $edge.Type.Name (list $edge.Name)) }}
-		{{ end }}
-		{{ if $mapping := $annotation.Mapping }}
-			{{ $edges = set $edges $edge.Name (list $edge.Type.Name $mapping) }}
-		{{ end }}
-	{{ else }}
-		{{ $edges = set $edges $edge.Name (list $edge.Type.Name (list $edge.Name)) }}
-	{{ end }}
-{{ end }}
-
 {{ $receiver := $node.Receiver }}
 {{ $query := $node.QueryName }}
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
@@ -43,12 +28,12 @@ func ({{ $receiver }} *{{ $query }}) CollectFields(ctx context.Context, satisfie
 }
 
 func ({{ $receiver }} *{{ $query }}) collectField(ctx *graphql.OperationContext, field graphql.CollectedField, satisfies ...string) *{{ $query }} {
-	{{- with $edges }}
+	{{- if $edges := fieldCollections (filterEdges $node.Edges) }}
 		for _, field := range graphql.CollectFields(ctx, field.Selections, satisfies) {
 			switch field.Name {
-				{{- range $name, $values := . }}
-					case {{ range $i, $value := index $values 1 }}{{ if gt $i 0 }}, {{ end }}"{{ $value }}"{{ end }}:
-						{{ $receiver }} = {{ $receiver }}.With{{ pascal $name }}(func(query *{{ pascal (index $values 0) }}Query) {
+				{{- range $name, $values := $edges }}
+					case {{ range $i, $value := $values.Mapping }}{{ if gt $i 0 }}, {{ end }}"{{ $value }}"{{ end }}:
+						{{ $receiver }} = {{ $receiver }}.With{{ pascal $name }}(func(query *{{ pascal $values.Name }}Query) {
 							query.collectField(ctx, field)
 						})
 				{{- end }}

--- a/entgql/template_test.go
+++ b/entgql/template_test.go
@@ -15,9 +15,10 @@
 package entgql
 
 import (
+	"testing"
+
 	"entgo.io/ent/entc/gen"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var annotationName = Annotation{}.Name()
@@ -99,6 +100,81 @@ func TestFilterEdges(t *testing.T) {
 			Type: &gen.Type{},
 		},
 	}, edges)
+}
+
+func TestFieldCollections(t *testing.T) {
+	edges, err := fieldCollections([]*gen.Edge{
+		{
+			Name: "Edge1",
+			Type: &gen.Type{
+				Name: "Todo",
+			},
+			Annotations: map[string]interface{}{
+				annotationName: map[string]interface{}{},
+			},
+		},
+		{
+			Name: "Edge2",
+			Type: &gen.Type{
+				Name: "Todo",
+			},
+		},
+		{
+			Name: "BindDisabled",
+			Type: &gen.Type{
+				Name: "Todo",
+			},
+			Annotations: map[string]interface{}{
+				annotationName: map[string]interface{}{
+					"BindDisabled": true,
+				},
+			},
+		},
+		{
+			Name: "EdgeMapping",
+			Type: &gen.Type{
+				Name: "Todo",
+			},
+			Annotations: map[string]interface{}{
+				annotationName: map[string]interface{}{
+					"BindDisabled": true,
+					"Mapping":      []string{"field1", "field2"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]fieldCollection{
+		"Edge1": {
+			Name:    "Todo",
+			Mapping: []string{"Edge1"},
+		},
+		"Edge2": {
+			Name:    "Todo",
+			Mapping: []string{"Edge2"},
+		},
+		"EdgeMapping": {
+			Name:    "Todo",
+			Mapping: []string{"field1", "field2"},
+		},
+	}, edges)
+
+	_, err = fieldCollections([]*gen.Edge{
+		{
+			Name: "EdgeInvalid",
+			Type: &gen.Type{
+				Name: "Todo",
+			},
+			Annotations: map[string]interface{}{
+				annotationName: map[string]interface{}{
+					"BindDisabled": false,
+					"Mapping":      []string{"field1", "field2"},
+				},
+			},
+		},
+	})
+	require.Errorf(t, err, "bind and mapping annotations are mutually exclusive")
 }
 
 func TestFilterFields(t *testing.T) {

--- a/entgql/template_test.go
+++ b/entgql/template_test.go
@@ -120,13 +120,13 @@ func TestFieldCollections(t *testing.T) {
 			},
 		},
 		{
-			Name: "BindDisabled",
+			Name: "Unbind",
 			Type: &gen.Type{
 				Name: "Todo",
 			},
 			Annotations: map[string]interface{}{
 				annotationName: map[string]interface{}{
-					"BindDisabled": true,
+					"Unbind": true,
 				},
 			},
 		},
@@ -137,8 +137,8 @@ func TestFieldCollections(t *testing.T) {
 			},
 			Annotations: map[string]interface{}{
 				annotationName: map[string]interface{}{
-					"BindDisabled": true,
-					"Mapping":      []string{"field1", "field2"},
+					"Unbind":  true,
+					"Mapping": []string{"field1", "field2"},
 				},
 			},
 		},
@@ -168,8 +168,8 @@ func TestFieldCollections(t *testing.T) {
 			},
 			Annotations: map[string]interface{}{
 				annotationName: map[string]interface{}{
-					"BindDisabled": false,
-					"Mapping":      []string{"field1", "field2"},
+					"Unbind":  false,
+					"Mapping": []string{"field1", "field2"},
 				},
 			},
 		},

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.9 h1:10HX2Td0ocZpYEjhilsuo6WWtUqttj2Kb0KtD86/KYA=
 github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -252,6 +253,7 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.0.2 h1:r4fFzBm+bv0wNKNh5eXTwU7i85y5x+uwkxCUTNVQqLc=
 github.com/oklog/ulid/v2 v2.0.2/go.mod h1:mtBL0Qe/0HAx6/a4Z30qxVIAL1eQDweXq5lxOEiwQ68=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
@@ -288,9 +290,11 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=


### PR DESCRIPTION
`Bind()` become a no-op function to avoid breaking the existing schema.

This commit also added `Unbind()` to disable bind.