### PR TITLE
chore: added devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.148.1/containers/go/.devcontainer/base.Dockerfile
+
+# [Choice] Go version: 1, 1.15, 1.14
+ARG VARIANT="1"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends protobuf-compiler
+
+# [Optional] Uncomment the next line to use go get to install anything else you need
+RUN su vscode -c "go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1 \
+  && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0 \
+  && go install entgo.io/contrib/entproto/cmd/protoc-gen-entgrpc@master"
+
+ENV PROTOBUF_VER=3.17.3
+ENV PROTOBUF_ZIP=protoc-${PROTOBUF_VER}-linux-x86_64.zip
+RUN curl -OL https://github.com/google/protobuf/releases/download/v${PROTOBUF_VER}/${PROTOBUF_ZIP} \
+  && unzip $PROTOBUF_ZIP -d protoc3 \
+  && mv protoc3/bin/* /usr/local/bin/ \
+  && mv protoc3/include/* /usr/local/include/ \
+  && rm -rf protoc3 $PROTOBUF_ZIP

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.15, 1.14
+			"VARIANT": "1.17"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go"
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8081],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
This PR setup devcontainer for everyone who works on VSCode, it also installs all tools to run `go generate ./...` without any additional steps.