### PR TITLE
Added support to generate byte fields.

### DIFF
--- a/schemast/field.go
+++ b/schemast/field.go
@@ -31,7 +31,7 @@ import (
 // to construct it.
 func Field(desc *field.Descriptor) (*ast.CallExpr, error) {
 	switch t := desc.Info.Type; {
-	case t.Numeric(), t == field.TypeString, t == field.TypeBool, t == field.TypeTime:
+	case t.Numeric(), t == field.TypeString, t == field.TypeBool, t == field.TypeTime, t == field.TypeBytes:
 		return fromSimpleType(desc)
 	case t == field.TypeEnum:
 		return fromEnumType(desc)

--- a/schemast/field_test.go
+++ b/schemast/field_test.go
@@ -132,6 +132,11 @@ func TestFromFieldDescriptor(t *testing.T) {
 			}),
 			expectedErrMsg: "schemast: unsupported feature Descriptor.Validators",
 		},
+		{
+			name:     "bytes",
+			field:    field.Bytes("x"),
+			expected: `field.Bytes("x")`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I was using entimport tool and was not able to generate schema files. Generating byte field was not supported for some reason. My column is defined as `BYTEA` in Postgres. After adding byte type to case switch entimport generated schema without problems