### PR TITLE
entgql: remove unnecessary `Funcs` call

### DIFF
--- a/entgql/template.go
+++ b/entgql/template.go
@@ -77,7 +77,6 @@ var (
 
 func parseT(path string) *gen.Template {
 	return gen.MustParse(gen.NewTemplate(path).
-		Funcs(gen.Funcs).
 		Funcs(TemplateFuncs).
 		ParseFS(templates, path))
 }


### PR DESCRIPTION
Because in `gen.NewTemplate()` we already call `t.Funcs(Funcs)`

https://github.com/ent/ent/blob/a7beb5c834f0b81de7afd15350da9c42d8eb6b88/entc/gen/template.go#L231-L235