### PR TITLE
entgql: add goModel directive to generated enums

### DIFF
--- a/entgql/internal/todoplugin/generated.go
+++ b/entgql/internal/todoplugin/generated.go
@@ -684,7 +684,7 @@ enum CategoryOrderField {
 """
 CategoryStatus is enum for the field status
 """
-enum CategoryStatus {
+enum CategoryStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/category.Status") {
 	ENABLED
 	DISABLED
 }
@@ -763,7 +763,7 @@ type PageInfo {
 """
 Role is enum for the field role
 """
-enum Role {
+enum Role @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/role.Role") {
 	ADMIN
 	USER
 	UNKNOWN
@@ -771,7 +771,7 @@ enum Role {
 """
 Status is enum for the field status
 """
-enum Status {
+enum Status @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.Status") {
 	IN_PROGRESS
 	COMPLETED
 }
@@ -824,7 +824,7 @@ enum TodoOrderField {
 """
 VisibilityStatus is enum for the field visibility_status
 """
-enum VisibilityStatus {
+enum VisibilityStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.VisibilityStatus") {
 	LISTING
 	HIDDEN
 }

--- a/entgql/schema_test.go
+++ b/entgql/schema_test.go
@@ -45,7 +45,7 @@ func TestEntGQL_buildTypes(t *testing.T) {
 """
 CategoryStatus is enum for the field status
 """
-enum CategoryStatus {
+enum CategoryStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/category.Status") {
 	ENABLED
 	DISABLED
 }
@@ -60,7 +60,7 @@ type MasterUser @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent
 """
 Role is enum for the field role
 """
-enum Role {
+enum Role @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/role.Role") {
 	ADMIN
 	USER
 	UNKNOWN
@@ -68,7 +68,7 @@ enum Role {
 """
 Status is enum for the field status
 """
-enum Status {
+enum Status @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.Status") {
 	IN_PROGRESS
 	COMPLETED
 }
@@ -83,7 +83,7 @@ type Todo {
 """
 VisibilityStatus is enum for the field visibility_status
 """
-enum VisibilityStatus {
+enum VisibilityStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.VisibilityStatus") {
 	LISTING
 	HIDDEN
 }
@@ -148,7 +148,7 @@ enum CategoryOrderField {
 """
 CategoryStatus is enum for the field status
 """
-enum CategoryStatus {
+enum CategoryStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/category.Status") {
 	ENABLED
 	DISABLED
 }
@@ -190,7 +190,7 @@ type MasterUserEdge {
 """
 Role is enum for the field role
 """
-enum Role {
+enum Role @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/role.Role") {
 	ADMIN
 	USER
 	UNKNOWN
@@ -198,7 +198,7 @@ enum Role {
 """
 Status is enum for the field status
 """
-enum Status {
+enum Status @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.Status") {
 	IN_PROGRESS
 	COMPLETED
 }
@@ -251,7 +251,7 @@ enum TodoOrderField {
 """
 VisibilityStatus is enum for the field visibility_status
 """
-enum VisibilityStatus {
+enum VisibilityStatus @goModel(model: "entgo.io/contrib/entgql/internal/todoplugin/ent/todo.VisibilityStatus") {
 	LISTING
 	HIDDEN
 }


### PR DESCRIPTION
Next PR, will add support for mapping fields with custom GoType to `goModel`.