### PR TITLE
added field annotation for read only flag

### DIFF
--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -32,8 +32,6 @@ type (
 		Example interface{}
 		// OpenAPI Specification schema to use for a schema field.
 		Schema *ogen.Schema
-		// FieldConfig has meta information about a schema field.
-		Field FieldConfig
 		// Create has meta information about a creation operation.
 		Create OperationConfig
 		// Read has meta information about a read operation.
@@ -44,6 +42,8 @@ type (
 		Delete OperationConfig
 		// List has meta information about a list operation.
 		List OperationConfig
+		// ReadOnly specifies that the field/edge is read only (no create/update parameter)
+		ReadOnly bool
 	}
 	// OperationConfig holds meta information about a REST operation.
 	OperationConfig struct {
@@ -52,10 +52,6 @@ type (
 	}
 	// OperationConfigOption allows managing OperationConfig using functional arguments.
 	OperationConfigOption func(*OperationConfig)
-	// FieldConfig hold meta information aboat a REST field (parameter)
-	FieldConfig struct {
-		ReadOnly bool
-	}
 )
 
 // Groups returns a OperationConfigOption that adds the given serialization groups to a OperationConfig.
@@ -102,6 +98,11 @@ func DeleteOperation(opts ...OperationConfigOption) Annotation {
 // ListOperation returns a list operation annotation.
 func ListOperation(opts ...OperationConfigOption) Annotation {
 	return Annotation{List: operationsConfig(opts)}
+}
+
+// ReadOnly returns a read only field/edge annotation
+func ReadOnly(readonly bool) Annotation {
+	return Annotation{ReadOnly: readonly}
 }
 
 func operationsConfig(opts []OperationConfigOption) OperationConfig {

--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -32,6 +32,8 @@ type (
 		Example interface{}
 		// OpenAPI Specification schema to use for a schema field.
 		Schema *ogen.Schema
+		// FieldConfig has meta information about a schema field.
+		Field FieldConfig
 		// Create has meta information about a creation operation.
 		Create OperationConfig
 		// Read has meta information about a read operation.

--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -50,6 +50,10 @@ type (
 	}
 	// OperationConfigOption allows managing OperationConfig using functional arguments.
 	OperationConfigOption func(*OperationConfig)
+	// FieldConfig hold meta information aboat a REST field (parameter)
+	FieldConfig struct {
+		ReadOnly bool
+	}
 )
 
 // Groups returns a OperationConfigOption that adds the given serialization groups to a OperationConfig.

--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -140,6 +140,9 @@ func (a Annotation) Merge(o schema.Annotation) schema.Annotation {
 	a.Update.merge(ant.Update)
 	a.Delete.merge(ant.Delete)
 	a.List.merge(ant.List)
+	if ant.ReadOnly {
+		a.ReadOnly = true
+	}
 	return a
 }
 

--- a/entoas/annotation_test.go
+++ b/entoas/annotation_test.go
@@ -26,7 +26,10 @@ import (
 func TestAnnotation(t *testing.T) {
 	t.Parallel()
 
-	a := Groups("create", "groups")
+	a := ReadOnly(true)
+	require.Equal(t, true, a.ReadOnly)
+
+	a = Groups("create", "groups")
 	require.Equal(t, serialization.Groups{"create", "groups"}, a.Groups)
 
 	a = CreateOperation(OperationGroups("create", "groups"), OperationPolicy(PolicyExpose))

--- a/entoas/annotation_test.go
+++ b/entoas/annotation_test.go
@@ -64,6 +64,10 @@ func TestAnnotation(t *testing.T) {
 	}
 	require.Equal(t, ex, a)
 
+	a = a.Merge(ReadOnly(true)).(Annotation)
+	ex.ReadOnly = true
+	require.Equal(t, ex, a)
+
 	ac, err := SchemaAnnotation(new(gen.Type))
 	require.NoError(t, err)
 	require.NotNil(t, ac)

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -667,7 +667,7 @@ func reqBody(n *gen.Type, op Operation) (*ogen.RequestBody, error) {
 		if err != nil {
 			return nil, err
 		}
-		if (a != nil && !a.Field.ReadOnly) && (op == OpCreate || !f.Immutable) {
+		if (a != nil && !a.ReadOnly) && (op == OpCreate || !f.Immutable) {
 			p, err := property(f)
 			if err != nil {
 				return nil, err

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -663,7 +663,11 @@ func reqBody(n *gen.Type, op Operation) (*ogen.RequestBody, error) {
 	}
 	c := ogen.NewSchema()
 	for _, f := range n.Fields {
-		if op == OpCreate || !f.Immutable {
+		a, err := FieldAnnotation(f)
+		if err != nil {
+			return nil, err
+		}
+		if (a != nil && !a.Field.ReadOnly) && (op == OpCreate || !f.Immutable) {
 			p, err := property(f)
 			if err != nil {
 				return nil, err

--- a/entoas/internal/simple/category.go
+++ b/entoas/internal/simple/category.go
@@ -17,6 +17,8 @@ type Category struct {
 	ID int `json:"id,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
+	// Readonly holds the value of the "readonly" field.
+	Readonly string `json:"readonly,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CategoryQuery when eager-loading is set.
 	Edges CategoryEdges `json:"edges"`
@@ -47,7 +49,7 @@ func (*Category) scanValues(columns []string) ([]interface{}, error) {
 		switch columns[i] {
 		case category.FieldID:
 			values[i] = new(sql.NullInt64)
-		case category.FieldName:
+		case category.FieldName, category.FieldReadonly:
 			values[i] = new(sql.NullString)
 		default:
 			return nil, fmt.Errorf("unexpected column %q for type Category", columns[i])
@@ -75,6 +77,12 @@ func (c *Category) assignValues(columns []string, values []interface{}) error {
 				return fmt.Errorf("unexpected type %T for field name", values[i])
 			} else if value.Valid {
 				c.Name = value.String
+			}
+		case category.FieldReadonly:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field readonly", values[i])
+			} else if value.Valid {
+				c.Readonly = value.String
 			}
 		}
 	}
@@ -111,6 +119,8 @@ func (c *Category) String() string {
 	builder.WriteString(fmt.Sprintf("id=%v", c.ID))
 	builder.WriteString(", name=")
 	builder.WriteString(c.Name)
+	builder.WriteString(", readonly=")
+	builder.WriteString(c.Readonly)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/entoas/internal/simple/category/category.go
+++ b/entoas/internal/simple/category/category.go
@@ -9,6 +9,8 @@ const (
 	FieldID = "id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
+	// FieldReadonly holds the string denoting the readonly field in the database.
+	FieldReadonly = "readonly"
 	// EdgePets holds the string denoting the pets edge name in mutations.
 	EdgePets = "pets"
 	// Table holds the table name of the category in the database.
@@ -24,6 +26,7 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldName,
+	FieldReadonly,
 }
 
 var (

--- a/entoas/internal/simple/category/where.go
+++ b/entoas/internal/simple/category/where.go
@@ -98,6 +98,13 @@ func Name(v string) predicate.Category {
 	})
 }
 
+// Readonly applies equality check predicate on the "readonly" field. It's identical to ReadonlyEQ.
+func Readonly(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldReadonly), v))
+	})
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Category {
 	return predicate.Category(func(s *sql.Selector) {
@@ -206,6 +213,117 @@ func NameEqualFold(v string) predicate.Category {
 func NameContainsFold(v string) predicate.Category {
 	return predicate.Category(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldName), v))
+	})
+}
+
+// ReadonlyEQ applies the EQ predicate on the "readonly" field.
+func ReadonlyEQ(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyNEQ applies the NEQ predicate on the "readonly" field.
+func ReadonlyNEQ(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyIn applies the In predicate on the "readonly" field.
+func ReadonlyIn(vs ...string) predicate.Category {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Category(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.In(s.C(FieldReadonly), v...))
+	})
+}
+
+// ReadonlyNotIn applies the NotIn predicate on the "readonly" field.
+func ReadonlyNotIn(vs ...string) predicate.Category {
+	v := make([]interface{}, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.Category(func(s *sql.Selector) {
+		// if not arguments were provided, append the FALSE constants,
+		// since we can't apply "IN ()". This will make this predicate falsy.
+		if len(v) == 0 {
+			s.Where(sql.False())
+			return
+		}
+		s.Where(sql.NotIn(s.C(FieldReadonly), v...))
+	})
+}
+
+// ReadonlyGT applies the GT predicate on the "readonly" field.
+func ReadonlyGT(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.GT(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyGTE applies the GTE predicate on the "readonly" field.
+func ReadonlyGTE(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.GTE(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyLT applies the LT predicate on the "readonly" field.
+func ReadonlyLT(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.LT(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyLTE applies the LTE predicate on the "readonly" field.
+func ReadonlyLTE(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.LTE(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyContains applies the Contains predicate on the "readonly" field.
+func ReadonlyContains(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.Contains(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyHasPrefix applies the HasPrefix predicate on the "readonly" field.
+func ReadonlyHasPrefix(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.HasPrefix(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyHasSuffix applies the HasSuffix predicate on the "readonly" field.
+func ReadonlyHasSuffix(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.HasSuffix(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyEqualFold applies the EqualFold predicate on the "readonly" field.
+func ReadonlyEqualFold(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.EqualFold(s.C(FieldReadonly), v))
+	})
+}
+
+// ReadonlyContainsFold applies the ContainsFold predicate on the "readonly" field.
+func ReadonlyContainsFold(v string) predicate.Category {
+	return predicate.Category(func(s *sql.Selector) {
+		s.Where(sql.ContainsFold(s.C(FieldReadonly), v))
 	})
 }
 

--- a/entoas/internal/simple/category_create.go
+++ b/entoas/internal/simple/category_create.go
@@ -26,6 +26,12 @@ func (cc *CategoryCreate) SetName(s string) *CategoryCreate {
 	return cc
 }
 
+// SetReadonly sets the "readonly" field.
+func (cc *CategoryCreate) SetReadonly(s string) *CategoryCreate {
+	cc.mutation.SetReadonly(s)
+	return cc
+}
+
 // AddPetIDs adds the "pets" edge to the Pet entity by IDs.
 func (cc *CategoryCreate) AddPetIDs(ids ...int) *CategoryCreate {
 	cc.mutation.AddPetIDs(ids...)
@@ -114,6 +120,9 @@ func (cc *CategoryCreate) check() error {
 	if _, ok := cc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`simple: missing required field "Category.name"`)}
 	}
+	if _, ok := cc.mutation.Readonly(); !ok {
+		return &ValidationError{Name: "readonly", err: errors.New(`simple: missing required field "Category.readonly"`)}
+	}
 	return nil
 }
 
@@ -148,6 +157,14 @@ func (cc *CategoryCreate) createSpec() (*Category, *sqlgraph.CreateSpec) {
 			Column: category.FieldName,
 		})
 		_node.Name = value
+	}
+	if value, ok := cc.mutation.Readonly(); ok {
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: category.FieldReadonly,
+		})
+		_node.Readonly = value
 	}
 	if nodes := cc.mutation.PetsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/entoas/internal/simple/category_update.go
+++ b/entoas/internal/simple/category_update.go
@@ -34,6 +34,12 @@ func (cu *CategoryUpdate) SetName(s string) *CategoryUpdate {
 	return cu
 }
 
+// SetReadonly sets the "readonly" field.
+func (cu *CategoryUpdate) SetReadonly(s string) *CategoryUpdate {
+	cu.mutation.SetReadonly(s)
+	return cu
+}
+
 // AddPetIDs adds the "pets" edge to the Pet entity by IDs.
 func (cu *CategoryUpdate) AddPetIDs(ids ...int) *CategoryUpdate {
 	cu.mutation.AddPetIDs(ids...)
@@ -154,6 +160,13 @@ func (cu *CategoryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Column: category.FieldName,
 		})
 	}
+	if value, ok := cu.mutation.Readonly(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: category.FieldReadonly,
+		})
+	}
 	if cu.mutation.PetsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -230,6 +243,12 @@ type CategoryUpdateOne struct {
 // SetName sets the "name" field.
 func (cuo *CategoryUpdateOne) SetName(s string) *CategoryUpdateOne {
 	cuo.mutation.SetName(s)
+	return cuo
+}
+
+// SetReadonly sets the "readonly" field.
+func (cuo *CategoryUpdateOne) SetReadonly(s string) *CategoryUpdateOne {
+	cuo.mutation.SetReadonly(s)
 	return cuo
 }
 
@@ -375,6 +394,13 @@ func (cuo *CategoryUpdateOne) sqlSave(ctx context.Context) (_node *Category, err
 			Type:   field.TypeString,
 			Value:  value,
 			Column: category.FieldName,
+		})
+	}
+	if value, ok := cuo.mutation.Readonly(); ok {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeString,
+			Value:  value,
+			Column: category.FieldReadonly,
 		})
 	}
 	if cuo.mutation.PetsCleared() {

--- a/entoas/internal/simple/migrate/schema.go
+++ b/entoas/internal/simple/migrate/schema.go
@@ -12,6 +12,7 @@ var (
 	CategoriesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "name", Type: field.TypeString},
+		{Name: "readonly", Type: field.TypeString},
 	}
 	// CategoriesTable holds the schema information for the "categories" table.
 	CategoriesTable = &schema.Table{

--- a/entoas/internal/simple/mutation.go
+++ b/entoas/internal/simple/mutation.go
@@ -37,6 +37,7 @@ type CategoryMutation struct {
 	typ           string
 	id            *int
 	name          *string
+	readonly      *string
 	clearedFields map[string]struct{}
 	pets          map[int]struct{}
 	removedpets   map[int]struct{}
@@ -180,6 +181,42 @@ func (m *CategoryMutation) ResetName() {
 	m.name = nil
 }
 
+// SetReadonly sets the "readonly" field.
+func (m *CategoryMutation) SetReadonly(s string) {
+	m.readonly = &s
+}
+
+// Readonly returns the value of the "readonly" field in the mutation.
+func (m *CategoryMutation) Readonly() (r string, exists bool) {
+	v := m.readonly
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldReadonly returns the old "readonly" field's value of the Category entity.
+// If the Category object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CategoryMutation) OldReadonly(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldReadonly is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldReadonly requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldReadonly: %w", err)
+	}
+	return oldValue.Readonly, nil
+}
+
+// ResetReadonly resets all changes to the "readonly" field.
+func (m *CategoryMutation) ResetReadonly() {
+	m.readonly = nil
+}
+
 // AddPetIDs adds the "pets" edge to the Pet entity by ids.
 func (m *CategoryMutation) AddPetIDs(ids ...int) {
 	if m.pets == nil {
@@ -253,9 +290,12 @@ func (m *CategoryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CategoryMutation) Fields() []string {
-	fields := make([]string, 0, 1)
+	fields := make([]string, 0, 2)
 	if m.name != nil {
 		fields = append(fields, category.FieldName)
+	}
+	if m.readonly != nil {
+		fields = append(fields, category.FieldReadonly)
 	}
 	return fields
 }
@@ -267,6 +307,8 @@ func (m *CategoryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case category.FieldName:
 		return m.Name()
+	case category.FieldReadonly:
+		return m.Readonly()
 	}
 	return nil, false
 }
@@ -278,6 +320,8 @@ func (m *CategoryMutation) OldField(ctx context.Context, name string) (ent.Value
 	switch name {
 	case category.FieldName:
 		return m.OldName(ctx)
+	case category.FieldReadonly:
+		return m.OldReadonly(ctx)
 	}
 	return nil, fmt.Errorf("unknown Category field %s", name)
 }
@@ -293,6 +337,13 @@ func (m *CategoryMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetName(v)
+		return nil
+	case category.FieldReadonly:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetReadonly(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Category field %s", name)
@@ -345,6 +396,9 @@ func (m *CategoryMutation) ResetField(name string) error {
 	switch name {
 	case category.FieldName:
 		m.ResetName()
+		return nil
+	case category.FieldReadonly:
+		m.ResetReadonly()
 		return nil
 	}
 	return fmt.Errorf("unknown Category field %s", name)

--- a/entoas/internal/simple/openapi.json
+++ b/entoas/internal/simple/openapi.json
@@ -1127,6 +1127,9 @@
           "name": {
             "type": "string"
           },
+          "readonly": {
+            "type": "string"
+          },
           "pets": {
             "type": "array",
             "items": {
@@ -1136,7 +1139,8 @@
         },
         "required": [
           "id",
-          "name"
+          "name",
+          "readonly"
         ]
       },
       "Pet": {

--- a/entoas/internal/simple/schema/category.go
+++ b/entoas/internal/simple/schema/category.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"entgo.io/contrib/entoas"
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
@@ -29,6 +30,9 @@ type Category struct {
 func (Category) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name"),
+		field.String("readonly").
+			Annotations(
+				entoas.Annotation{ReadOnly: true}),
 	}
 }
 


### PR DESCRIPTION
Added FieldConfig struct to Annotation to support read only fields. Corresponding change coming to ogent that uses this flag to suppress parameter generation for read only fields (usefult for createdBy and createdAt fields).