### PR TITLE
Added two new parameter to filter and sort a list of models.

### DIFF
--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -432,6 +432,16 @@ func listOp(spec *ogen.Spec, n *gen.Type) (*ogen.Operation, error) {
 				SetName("itemsPerPage").
 				SetDescription("item count to render per page").
 				SetSchema(ogen.Int()),
+			ogen.NewParameter().
+				InQuery().
+				SetName("orderBy").
+				SetDescription("clause is used to sort the records in the result set for a SELECT statement.").
+				SetSchema(ogen.String()),
+			ogen.NewParameter().
+				InQuery().
+				SetName("filter").
+				SetDescription("text strings that you use to specify a subset of the data items").
+				SetSchema(ogen.String()),
 		).
 		AddResponse(
 			strconv.Itoa(http.StatusOK),
@@ -478,6 +488,16 @@ func listEdgeOp(spec *ogen.Spec, n *gen.Type, e *gen.Edge) (*ogen.Operation, err
 				SetName("itemsPerPage").
 				SetDescription("item count to render per page").
 				SetSchema(ogen.Int()),
+			ogen.NewParameter().
+				InQuery().
+				SetName("orderBy").
+				SetDescription("clause is used to sort the records in the result set for a SELECT statement.").
+				SetSchema(ogen.String()),
+			ogen.NewParameter().
+				InQuery().
+				SetName("filter").
+				SetDescription("text strings that you use to specify a subset of the data items").
+				SetSchema(ogen.String()),
 		).
 		AddResponse(
 			strconv.Itoa(http.StatusOK),


### PR DESCRIPTION
Added two new parameters for API. OrderBy and filter.
The value of the **orderBy** parameter contains a comma-separated list of expressions used to sort the items. A special case of such an expression is a property path terminating on a primitive property.
The **filter** querystring parameter allows clients to filter a collection of resources that are addressed by a request URL