### PR TITLE
schemast: proper float field conversion

### DIFF
--- a/schemast/field.go
+++ b/schemast/field.go
@@ -209,7 +209,11 @@ func fromSimpleType(desc *field.Descriptor) (*ast.CallExpr, error) {
 }
 
 func fieldConstructor(dsc *field.Descriptor) string {
-	return strings.TrimPrefix(dsc.Info.ConstName(), "Type")
+	cn := dsc.Info.ConstName()
+	if dsc.Info.Type == field.TypeFloat64 {
+		cn = strings.TrimSuffix(cn, "64")
+	}
+	return strings.TrimPrefix(cn, "Type")
 }
 
 func defaultExpr(d interface{}) (ast.Expr, error) {

--- a/schemast/field_test.go
+++ b/schemast/field_test.go
@@ -122,6 +122,16 @@ func TestFromFieldDescriptor(t *testing.T) {
 			expected: `field.Float32("x").Default(3.14)`,
 		},
 		{
+			name:     "float64",
+			field:    field.Float("x"),
+			expected: `field.Float("x")`,
+		},
+		{
+			name:     "default:float64",
+			field:    field.Float("x").Default(2.718),
+			expected: `field.Float("x").Default(2.718)`,
+		},
+		{
 			name:     "default:bool",
 			field:    field.Bool("x").Default(true),
 			expected: `field.Bool("x").Default(true)`,


### PR DESCRIPTION
ent is using `Float` and not `Float64` as the float64 field, this fix handles it.

```
// Float returns a new Field with type float64.
func Float(name string) *float64Builder {
	return &float64Builder{&Descriptor{
		Name: name,
		Info: &TypeInfo{Type: TypeFloat64},
	}}
}
```