### PR TITLE
entoas: fix merge bug

### DIFF
--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -17,10 +17,11 @@ package entoas
 import (
 	"encoding/json"
 
-	"entgo.io/contrib/entoas/serialization"
 	"entgo.io/ent/entc/gen"
 	"entgo.io/ent/schema"
 	"github.com/ogen-go/ogen"
+
+	"entgo.io/contrib/entoas/serialization"
 )
 
 type (
@@ -146,14 +147,14 @@ func (a Annotation) Merge(o schema.Annotation) schema.Annotation {
 	return a
 }
 
-func (op OperationConfig) merge(other OperationConfig) OperationConfig {
+func (op *OperationConfig) merge(other OperationConfig) OperationConfig {
 	if other.Policy != PolicyNone {
 		op.Policy = other.Policy
 	}
 	if other.Groups != nil {
 		op.Groups = other.Groups
 	}
-	return op
+	return *op
 }
 
 // Decode from ent.

--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -17,11 +17,10 @@ package entoas
 import (
 	"encoding/json"
 
+	"entgo.io/contrib/entoas/serialization"
 	"entgo.io/ent/entc/gen"
 	"entgo.io/ent/schema"
 	"github.com/ogen-go/ogen"
-
-	"entgo.io/contrib/entoas/serialization"
 )
 
 type (
@@ -147,14 +146,13 @@ func (a Annotation) Merge(o schema.Annotation) schema.Annotation {
 	return a
 }
 
-func (op *OperationConfig) merge(other OperationConfig) OperationConfig {
+func (op *OperationConfig) merge(other OperationConfig) {
 	if other.Policy != PolicyNone {
 		op.Policy = other.Policy
 	}
 	if other.Groups != nil {
 		op.Groups = other.Groups
 	}
-	return *op
 }
 
 // Decode from ent.

--- a/entoas/annotation_test.go
+++ b/entoas/annotation_test.go
@@ -17,11 +17,10 @@ package entoas
 import (
 	"testing"
 
+	"entgo.io/contrib/entoas/serialization"
 	"entgo.io/ent/entc/gen"
 	"github.com/ogen-go/ogen"
 	"github.com/stretchr/testify/require"
-
-	"entgo.io/contrib/entoas/serialization"
 )
 
 func TestAnnotation(t *testing.T) {

--- a/entoas/annotation_test.go
+++ b/entoas/annotation_test.go
@@ -17,10 +17,11 @@ package entoas
 import (
 	"testing"
 
-	"entgo.io/contrib/entoas/serialization"
 	"entgo.io/ent/entc/gen"
 	"github.com/ogen-go/ogen"
 	"github.com/stretchr/testify/require"
+
+	"entgo.io/contrib/entoas/serialization"
 )
 
 func TestAnnotation(t *testing.T) {
@@ -67,6 +68,19 @@ func TestAnnotation(t *testing.T) {
 	a = a.Merge(ReadOnly(true)).(Annotation)
 	ex.ReadOnly = true
 	require.Equal(t, ex, a)
+
+	crOp := CreateOperation(OperationPolicy(PolicyExpose))
+	dlOp := DeleteOperation(OperationPolicy(PolicyExclude))
+	crdlEx := Annotation{
+		Create: OperationConfig{
+			Policy: PolicyExpose,
+		},
+		Delete: OperationConfig{
+			Policy: PolicyExclude,
+		},
+	}
+	crOp = crOp.Merge(dlOp).(Annotation)
+	require.Equal(t, crdlEx, crOp)
 
 	ac, err := SchemaAnnotation(new(gen.Type))
 	require.NoError(t, err)


### PR DESCRIPTION
The bug was due to using a copy instead of a reference