### PR TITLE
entgql: cleanup queryField annotation

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -162,17 +162,22 @@ func Directives(directives ...Directive) Annotation {
 	return Annotation{Directives: directives}
 }
 
-// QueryFieldDirectives returns a Directives annotation.
-func QueryFieldDirectives(directives ...Directive) Annotation {
-	return Annotation{QueryField: &FieldConfig{Directives: directives}}
+type QueryFieldAnnotation struct {
+	Annotation
 }
 
 // QueryField returns an annotation for expose the field on the Query type.
-func QueryField(name ...string) Annotation {
+func QueryField(name ...string) QueryFieldAnnotation {
+	a := Annotation{QueryField: &FieldConfig{}}
 	if len(name) > 0 {
-		return Annotation{QueryField: &FieldConfig{Name: name[0]}}
+		a.QueryField.Name = name[0]
 	}
-	return Annotation{QueryField: &FieldConfig{}}
+	return QueryFieldAnnotation{Annotation: a}
+}
+
+func (a QueryFieldAnnotation) Directives(directives ...Directive) QueryFieldAnnotation {
+	a.QueryField.Directives = directives
+	return a
 }
 
 // Merge implements the schema.Merger interface.
@@ -184,6 +189,12 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	case *Annotation:
 		if other != nil {
 			ant = *other
+		}
+	case QueryFieldAnnotation:
+		ant = other.Annotation
+	case *QueryFieldAnnotation:
+		if other != nil {
+			ant = other.Annotation
 		}
 	default:
 		return a

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -162,20 +162,21 @@ func Directives(directives ...Directive) Annotation {
 	return Annotation{Directives: directives}
 }
 
-type QueryFieldAnnotation struct {
+type queryFieldAnnotation struct {
 	Annotation
 }
 
 // QueryField returns an annotation for expose the field on the Query type.
-func QueryField(name ...string) QueryFieldAnnotation {
+func QueryField(name ...string) queryFieldAnnotation {
 	a := Annotation{QueryField: &FieldConfig{}}
 	if len(name) > 0 {
 		a.QueryField.Name = name[0]
 	}
-	return QueryFieldAnnotation{Annotation: a}
+	return queryFieldAnnotation{Annotation: a}
 }
 
-func (a QueryFieldAnnotation) Directives(directives ...Directive) QueryFieldAnnotation {
+// Directives allow you apply directives to the field.
+func (a queryFieldAnnotation) Directives(directives ...Directive) queryFieldAnnotation {
 	a.QueryField.Directives = directives
 	return a
 }
@@ -190,9 +191,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 		if other != nil {
 			ant = *other
 		}
-	case QueryFieldAnnotation:
+	case queryFieldAnnotation:
 		ant = other.Annotation
-	case *QueryFieldAnnotation:
+	case *queryFieldAnnotation:
 		if other != nil {
 			ant = other.Annotation
 		}


### PR DESCRIPTION
I change the API to a chain, to be cleaner.
```go
entgql.QueryField().
	Directives(entgql.Deprecated("we don't use this anymore")),
```