### PR TITLE
entgql: fix example code in comment

### DIFF
--- a/entgql/internal/todo/ent/gql_node.go
+++ b/entgql/internal/todo/ent/gql_node.go
@@ -321,7 +321,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todo/ent/gql_node.go
+++ b/entgql/internal/todo/ent/gql_node.go
@@ -321,7 +321,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todofed/ent/gql_node.go
+++ b/entgql/internal/todofed/ent/gql_node.go
@@ -261,7 +261,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todofed/ent/gql_node.go
+++ b/entgql/internal/todofed/ent/gql_node.go
@@ -261,7 +261,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todoplugin/ent/gql_node.go
+++ b/entgql/internal/todoplugin/ent/gql_node.go
@@ -311,7 +311,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todoplugin/ent/gql_node.go
+++ b/entgql/internal/todoplugin/ent/gql_node.go
@@ -311,7 +311,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todopulid/ent/gql_node.go
+++ b/entgql/internal/todopulid/ent/gql_node.go
@@ -316,7 +316,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id pulid.ID, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todopulid/ent/gql_node.go
+++ b/entgql/internal/todopulid/ent/gql_node.go
@@ -316,7 +316,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id pulid.ID, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todouuid/ent/gql_node.go
+++ b/entgql/internal/todouuid/ent/gql_node.go
@@ -316,7 +316,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id uuid.UUID, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/internal/todouuid/ent/gql_node.go
+++ b/entgql/internal/todouuid/ent/gql_node.go
@@ -316,7 +316,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id uuid.UUID, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/template/node.tmpl
+++ b/entgql/template/node.tmpl
@@ -160,7 +160,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(pet.Table))
+//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id {{ $idType }}, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {

--- a/entgql/template/node.tmpl
+++ b/entgql/template/node.tmpl
@@ -160,7 +160,7 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // be derived from the id value according to the universal-id configuration.
 //
 //		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(someTypeResolver))
+//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 //
 func (c *Client) Noder(ctx context.Context, id {{ $idType }}, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {


### PR DESCRIPTION
Hi, this is minor fix of example code in a comment.

Before fix, a example WithNodeType() receives a string.
Correct argument of the function is a function.
It was changed in below commit.
https://github.com/ent/contrib/commit/84ba3303a11cf67f0bd58e96d80cfa7bfc0600fb

However, the document has been updated.
https://entgo.io/docs/graphql/#node-api