### PR TITLE
entgql: add WithRelaySpec to be able to disable Relay specification

### DIFF
--- a/entgql/extension.go
+++ b/entgql/extension.go
@@ -134,6 +134,14 @@ func WithWhereInputs(b bool) ExtensionOption {
 	}
 }
 
+// WithRelaySpec enables or disables generating the Relay Node interface.
+func WithRelaySpec(enabled bool) ExtensionOption {
+	return func(e *Extension) error {
+		e.relaySpec = enabled
+		return nil
+	}
+}
+
 // WithSchemaGenerator add a hook for generate GQL schema
 func WithSchemaGenerator() ExtensionOption {
 	return func(e *Extension) error {


### PR DESCRIPTION
The naming is based on this comment: https://github.com/ent/contrib/blob/1faab982b6648b7704a6cf41ff65d9cb7811a2be/entgql/schema.go#L45