### PR TITLE
entgql: Allow using Relay Connection without Node support

### DIFF
--- a/entgql/extension.go
+++ b/entgql/extension.go
@@ -134,10 +134,27 @@ func WithWhereInputs(b bool) ExtensionOption {
 	}
 }
 
-// WithRelaySpec enables or disables generating the Relay Node interface.
+// WithRelaySpec enables or disables Relay Node and Connection support.
 func WithRelaySpec(enabled bool) ExtensionOption {
 	return func(e *Extension) error {
-		e.relaySpec = enabled
+		e.relayNode = enabled
+		e.relayConnection = enabled
+		return nil
+	}
+}
+
+// WithRelayNode enables or disables generating the Relay Node interface.
+func WithRelayNode(enabled bool) ExtensionOption {
+	return func(e *Extension) error {
+		e.relayNode = enabled
+		return nil
+	}
+}
+
+// WithRelayConnection enables or disables generating Relay Connection support.
+func WithRelayConnection(enabled bool) ExtensionOption {
+	return func(e *Extension) error {
+		e.relayConnection = enabled
 		return nil
 	}
 }

--- a/entgql/schema_test.go
+++ b/entgql/schema_test.go
@@ -35,7 +35,8 @@ func TestEntGQL_buildTypes(t *testing.T) {
 	disableRelayConnection(graph)
 	plugin := newSchemaGenerator()
 	plugin.genSchema = true
-	plugin.relaySpec = false
+	plugin.relayNode = false
+	plugin.relayConnection = false
 
 	schema := &ast.Schema{
 		Types: make(map[string]*ast.Definition),
@@ -751,7 +752,10 @@ type PageInfo {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := relayBuiltinTypes("todo/ent")
+			got := append(
+				relayBuiltinConnectionTypes("todo/ent"),
+				relayBuiltinNodeType("todo/ent"),
+			)
 
 			s := &ast.Schema{}
 			s.AddTypes(got...)


### PR DESCRIPTION
Motivation: I want to use the Relay Connection support, but without exposing the Node interface, as the Node interface doesn't seem to use field resolvers and instead reads data directly.