### PR TITLE
use uint64 for TotalCount

### DIFF
--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -261,7 +261,7 @@ func (c *{{ $conn }}) build(nodes []*{{ $name }}, pager *{{ $pager }}, after *Cu
 		nodes = nodes[:len(nodes)-1]
 	} else if last != nil && *last+1 == len(nodes) {
 		c.PageInfo.HasPreviousPage = true
-		nodes = nodes[:len(nodes)-1]
+		nodes = uint64(nodes[:len(nodes)-1])
 	}
 	var nodeAt func(int) *{{ $name }}
 	if last != nil {

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -248,7 +248,7 @@ type {{ $edge }} struct {
 type {{ $conn }} struct {
 	Edges []*{{ $edge }} `json:"edges"`
 	PageInfo PageInfo    `json:"pageInfo"`
-	TotalCount int       `json:"totalCount"`
+	TotalCount uint64    `json:"totalCount"`
 }
 
 {{ $pager := print (camel $name) "Pager" }}


### PR DESCRIPTION
I think using uint instead of int because the number can never be negative.