### PR TITLE
entgql: skip empty top-level where inputs

### DIFF
--- a/entgql/internal/todo/ent/gql_where_input.go
+++ b/entgql/internal/todo/ent/gql_where_input.go
@@ -17,6 +17,7 @@
 package ent
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -119,10 +120,16 @@ func (i *CategoryWhereInput) Filter(q *CategoryQuery) (*CategoryQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyCategoryWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyCategoryWhereInput is returned in case the CategoryWhereInput is empty.
+var ErrEmptyCategoryWhereInput = errors.New("ent: empty predicate CategoryWhereInput")
 
 // P returns a predicate for filtering categories.
 // An error is returned if the input is empty or invalid.
@@ -131,7 +138,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, category.Not(p))
 	}
@@ -139,7 +146,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -147,7 +154,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -157,7 +164,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -165,7 +172,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -350,7 +357,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.HasTodosWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasTodosWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -358,7 +365,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate CategoryWhereInput")
+		return nil, ErrEmptyCategoryWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -415,10 +422,16 @@ func (i *GroupWhereInput) Filter(q *GroupQuery) (*GroupQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyGroupWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyGroupWhereInput is returned in case the GroupWhereInput is empty.
+var ErrEmptyGroupWhereInput = errors.New("ent: empty predicate GroupWhereInput")
 
 // P returns a predicate for filtering groups.
 // An error is returned if the input is empty or invalid.
@@ -427,7 +440,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, group.Not(p))
 	}
@@ -435,7 +448,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -443,7 +456,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -453,7 +466,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -461,7 +474,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -544,7 +557,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.HasUsersWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasUsersWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -552,7 +565,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate GroupWhereInput")
+		return nil, ErrEmptyGroupWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -651,10 +664,16 @@ func (i *TodoWhereInput) Filter(q *TodoQuery) (*TodoQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyTodoWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyTodoWhereInput is returned in case the TodoWhereInput is empty.
+var ErrEmptyTodoWhereInput = errors.New("ent: empty predicate TodoWhereInput")
 
 // P returns a predicate for filtering todos.
 // An error is returned if the input is empty or invalid.
@@ -663,7 +682,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, todo.Not(p))
 	}
@@ -671,7 +690,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -679,7 +698,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -689,7 +708,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -697,7 +716,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -858,7 +877,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasParentWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasParentWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -876,7 +895,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasChildrenWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasChildrenWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -894,7 +913,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasCategoryWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasCategoryWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -902,7 +921,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate TodoWhereInput")
+		return nil, ErrEmptyTodoWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -963,10 +982,16 @@ func (i *UserWhereInput) Filter(q *UserQuery) (*UserQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyUserWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyUserWhereInput is returned in case the UserWhereInput is empty.
+var ErrEmptyUserWhereInput = errors.New("ent: empty predicate UserWhereInput")
 
 // P returns a predicate for filtering users.
 // An error is returned if the input is empty or invalid.
@@ -975,7 +1000,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, user.Not(p))
 	}
@@ -983,7 +1008,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -991,7 +1016,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -1001,7 +1026,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1009,7 +1034,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -1092,7 +1117,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasGroupsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasGroupsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1110,7 +1135,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasFriendsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasFriendsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1118,7 +1143,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate UserWhereInput")
+		return nil, ErrEmptyUserWhereInput
 	case 1:
 		return predicates[0], nil
 	default:

--- a/entgql/internal/todo/todo_test.go
+++ b/entgql/internal/todo/todo_test.go
@@ -603,6 +603,7 @@ func (s *todoTestSuite) TestPaginationFiltering() {
 		s.Require().NoError(err)
 		s.Require().Equal(0, rsp.Todos.TotalCount)
 	})
+
 	s.Run("WithCategory", func() {
 		ctx := context.Background()
 		id := s.ent.Todo.Query().Order(ent.Asc(todo.FieldID)).FirstIDX(ctx)
@@ -622,6 +623,20 @@ func (s *todoTestSuite) TestPaginationFiltering() {
 		err = s.Post(query, &rsp, client.Var("duration", time.Second*2))
 		s.NoError(err)
 		s.Zero(rsp.Todos.TotalCount)
+	})
+
+	s.Run("EmptyFilter", func() {
+		var (
+			rsp   response
+			query = `query() {
+				todos(where:{}) {
+					totalCount
+				}
+			}`
+		)
+		err := s.Post(query, &rsp)
+		s.NoError(err)
+		s.Equal(s.ent.Todo.Query().CountX(context.Background()), rsp.Todos.TotalCount)
 	})
 }
 

--- a/entgql/internal/todogotype/ent/gql_where_input.go
+++ b/entgql/internal/todogotype/ent/gql_where_input.go
@@ -17,6 +17,7 @@
 package ent
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -122,10 +123,16 @@ func (i *CategoryWhereInput) Filter(q *CategoryQuery) (*CategoryQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyCategoryWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyCategoryWhereInput is returned in case the CategoryWhereInput is empty.
+var ErrEmptyCategoryWhereInput = errors.New("ent: empty predicate CategoryWhereInput")
 
 // P returns a predicate for filtering categories.
 // An error is returned if the input is empty or invalid.
@@ -134,7 +141,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, category.Not(p))
 	}
@@ -142,7 +149,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -150,7 +157,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -160,7 +167,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -168,7 +175,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -353,7 +360,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.HasTodosWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasTodosWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -361,7 +368,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate CategoryWhereInput")
+		return nil, ErrEmptyCategoryWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -418,10 +425,16 @@ func (i *GroupWhereInput) Filter(q *GroupQuery) (*GroupQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyGroupWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyGroupWhereInput is returned in case the GroupWhereInput is empty.
+var ErrEmptyGroupWhereInput = errors.New("ent: empty predicate GroupWhereInput")
 
 // P returns a predicate for filtering groups.
 // An error is returned if the input is empty or invalid.
@@ -430,7 +443,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, group.Not(p))
 	}
@@ -438,7 +451,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -446,7 +459,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -456,7 +469,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -464,7 +477,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -547,7 +560,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.HasUsersWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasUsersWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -555,7 +568,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate GroupWhereInput")
+		return nil, ErrEmptyGroupWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -608,10 +621,16 @@ func (i *PetWhereInput) Filter(q *PetQuery) (*PetQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyPetWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyPetWhereInput is returned in case the PetWhereInput is empty.
+var ErrEmptyPetWhereInput = errors.New("ent: empty predicate PetWhereInput")
 
 // P returns a predicate for filtering pets.
 // An error is returned if the input is empty or invalid.
@@ -620,7 +639,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, pet.Not(p))
 	}
@@ -628,7 +647,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -636,7 +655,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -646,7 +665,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -654,7 +673,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -727,7 +746,7 @@ func (i *PetWhereInput) P() (predicate.Pet, error) {
 
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate PetWhereInput")
+		return nil, ErrEmptyPetWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -835,10 +854,16 @@ func (i *TodoWhereInput) Filter(q *TodoQuery) (*TodoQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyTodoWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyTodoWhereInput is returned in case the TodoWhereInput is empty.
+var ErrEmptyTodoWhereInput = errors.New("ent: empty predicate TodoWhereInput")
 
 // P returns a predicate for filtering todos.
 // An error is returned if the input is empty or invalid.
@@ -847,7 +872,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, todo.Not(p))
 	}
@@ -855,7 +880,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -863,7 +888,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -873,7 +898,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -881,7 +906,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -1069,7 +1094,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasParentWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasParentWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1087,7 +1112,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasChildrenWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasChildrenWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1105,7 +1130,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasCategoryWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasCategoryWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1113,7 +1138,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate TodoWhereInput")
+		return nil, ErrEmptyTodoWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -1174,10 +1199,16 @@ func (i *UserWhereInput) Filter(q *UserQuery) (*UserQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyUserWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyUserWhereInput is returned in case the UserWhereInput is empty.
+var ErrEmptyUserWhereInput = errors.New("ent: empty predicate UserWhereInput")
 
 // P returns a predicate for filtering users.
 // An error is returned if the input is empty or invalid.
@@ -1186,7 +1217,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, user.Not(p))
 	}
@@ -1194,7 +1225,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1202,7 +1233,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -1212,7 +1243,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1220,7 +1251,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -1303,7 +1334,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasGroupsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasGroupsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1321,7 +1352,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasFriendsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasFriendsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1329,7 +1360,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate UserWhereInput")
+		return nil, ErrEmptyUserWhereInput
 	case 1:
 		return predicates[0], nil
 	default:

--- a/entgql/internal/todopulid/ent/gql_where_input.go
+++ b/entgql/internal/todopulid/ent/gql_where_input.go
@@ -17,6 +17,7 @@
 package ent
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -120,10 +121,16 @@ func (i *CategoryWhereInput) Filter(q *CategoryQuery) (*CategoryQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyCategoryWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyCategoryWhereInput is returned in case the CategoryWhereInput is empty.
+var ErrEmptyCategoryWhereInput = errors.New("ent: empty predicate CategoryWhereInput")
 
 // P returns a predicate for filtering categories.
 // An error is returned if the input is empty or invalid.
@@ -132,7 +139,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, category.Not(p))
 	}
@@ -140,7 +147,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -148,7 +155,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -158,7 +165,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -166,7 +173,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -351,7 +358,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.HasTodosWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasTodosWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -359,7 +366,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate CategoryWhereInput")
+		return nil, ErrEmptyCategoryWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -416,10 +423,16 @@ func (i *GroupWhereInput) Filter(q *GroupQuery) (*GroupQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyGroupWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyGroupWhereInput is returned in case the GroupWhereInput is empty.
+var ErrEmptyGroupWhereInput = errors.New("ent: empty predicate GroupWhereInput")
 
 // P returns a predicate for filtering groups.
 // An error is returned if the input is empty or invalid.
@@ -428,7 +441,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, group.Not(p))
 	}
@@ -436,7 +449,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -444,7 +457,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -454,7 +467,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -462,7 +475,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -545,7 +558,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.HasUsersWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasUsersWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -553,7 +566,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate GroupWhereInput")
+		return nil, ErrEmptyGroupWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -661,10 +674,16 @@ func (i *TodoWhereInput) Filter(q *TodoQuery) (*TodoQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyTodoWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyTodoWhereInput is returned in case the TodoWhereInput is empty.
+var ErrEmptyTodoWhereInput = errors.New("ent: empty predicate TodoWhereInput")
 
 // P returns a predicate for filtering todos.
 // An error is returned if the input is empty or invalid.
@@ -673,7 +692,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, todo.Not(p))
 	}
@@ -681,7 +700,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -689,7 +708,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -699,7 +718,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -707,7 +726,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -895,7 +914,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasParentWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasParentWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -913,7 +932,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasChildrenWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasChildrenWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -931,7 +950,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasCategoryWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasCategoryWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -939,7 +958,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate TodoWhereInput")
+		return nil, ErrEmptyTodoWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -1000,10 +1019,16 @@ func (i *UserWhereInput) Filter(q *UserQuery) (*UserQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyUserWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyUserWhereInput is returned in case the UserWhereInput is empty.
+var ErrEmptyUserWhereInput = errors.New("ent: empty predicate UserWhereInput")
 
 // P returns a predicate for filtering users.
 // An error is returned if the input is empty or invalid.
@@ -1012,7 +1037,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, user.Not(p))
 	}
@@ -1020,7 +1045,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1028,7 +1053,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -1038,7 +1063,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1046,7 +1071,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -1129,7 +1154,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasGroupsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasGroupsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1147,7 +1172,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasFriendsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasFriendsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1155,7 +1180,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate UserWhereInput")
+		return nil, ErrEmptyUserWhereInput
 	case 1:
 		return predicates[0], nil
 	default:

--- a/entgql/internal/todouuid/ent/gql_where_input.go
+++ b/entgql/internal/todouuid/ent/gql_where_input.go
@@ -17,6 +17,7 @@
 package ent
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -120,10 +121,16 @@ func (i *CategoryWhereInput) Filter(q *CategoryQuery) (*CategoryQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyCategoryWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyCategoryWhereInput is returned in case the CategoryWhereInput is empty.
+var ErrEmptyCategoryWhereInput = errors.New("ent: empty predicate CategoryWhereInput")
 
 // P returns a predicate for filtering categories.
 // An error is returned if the input is empty or invalid.
@@ -132,7 +139,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, category.Not(p))
 	}
@@ -140,7 +147,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -148,7 +155,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -158,7 +165,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -166,7 +173,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -351,7 +358,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 		for _, w := range i.HasTodosWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasTodosWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -359,7 +366,7 @@ func (i *CategoryWhereInput) P() (predicate.Category, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate CategoryWhereInput")
+		return nil, ErrEmptyCategoryWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -416,10 +423,16 @@ func (i *GroupWhereInput) Filter(q *GroupQuery) (*GroupQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyGroupWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyGroupWhereInput is returned in case the GroupWhereInput is empty.
+var ErrEmptyGroupWhereInput = errors.New("ent: empty predicate GroupWhereInput")
 
 // P returns a predicate for filtering groups.
 // An error is returned if the input is empty or invalid.
@@ -428,7 +441,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, group.Not(p))
 	}
@@ -436,7 +449,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -444,7 +457,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -454,7 +467,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -462,7 +475,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -545,7 +558,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 		for _, w := range i.HasUsersWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasUsersWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -553,7 +566,7 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate GroupWhereInput")
+		return nil, ErrEmptyGroupWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -652,10 +665,16 @@ func (i *TodoWhereInput) Filter(q *TodoQuery) (*TodoQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyTodoWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyTodoWhereInput is returned in case the TodoWhereInput is empty.
+var ErrEmptyTodoWhereInput = errors.New("ent: empty predicate TodoWhereInput")
 
 // P returns a predicate for filtering todos.
 // An error is returned if the input is empty or invalid.
@@ -664,7 +683,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, todo.Not(p))
 	}
@@ -672,7 +691,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -680,7 +699,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -690,7 +709,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -698,7 +717,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -859,7 +878,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasParentWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasParentWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -877,7 +896,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasChildrenWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasChildrenWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -895,7 +914,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 		for _, w := range i.HasCategoryWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasCategoryWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -903,7 +922,7 @@ func (i *TodoWhereInput) P() (predicate.Todo, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate TodoWhereInput")
+		return nil, ErrEmptyTodoWhereInput
 	case 1:
 		return predicates[0], nil
 	default:
@@ -964,10 +983,16 @@ func (i *UserWhereInput) Filter(q *UserQuery) (*UserQuery, error) {
 	}
 	p, err := i.P()
 	if err != nil {
+		if err == ErrEmptyUserWhereInput {
+			return q, nil
+		}
 		return nil, err
 	}
 	return q.Where(p), nil
 }
+
+// ErrEmptyUserWhereInput is returned in case the UserWhereInput is empty.
+var ErrEmptyUserWhereInput = errors.New("ent: empty predicate UserWhereInput")
 
 // P returns a predicate for filtering users.
 // An error is returned if the input is empty or invalid.
@@ -976,7 +1001,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	if i.Not != nil {
 		p, err := i.Not.P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'not'", err)
 		}
 		predicates = append(predicates, user.Not(p))
 	}
@@ -984,7 +1009,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.Or[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'or'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -992,7 +1017,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.Or {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'or'", err)
 			}
 			or = append(or, p)
 		}
@@ -1002,7 +1027,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	case n == 1:
 		p, err := i.And[0].P()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: field 'and'", err)
 		}
 		predicates = append(predicates, p)
 	case n > 1:
@@ -1010,7 +1035,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.And {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'and'", err)
 			}
 			and = append(and, p)
 		}
@@ -1093,7 +1118,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasGroupsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasGroupsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1111,7 +1136,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 		for _, w := range i.HasFriendsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%w: field 'HasFriendsWith'", err)
 			}
 			with = append(with, p)
 		}
@@ -1119,7 +1144,7 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	}
 	switch len(predicates) {
 	case 0:
-		return nil, fmt.Errorf("empty predicate UserWhereInput")
+		return nil, ErrEmptyUserWhereInput
 	case 1:
 		return predicates[0], nil
 	default:

--- a/entgql/template/where_input.tmpl
+++ b/entgql/template/where_input.tmpl
@@ -77,6 +77,8 @@ in the LICENSE file in the root directory of this source tree.
         i.Predicates = append(i.Predicates, predicates...)
     }
 
+    {{ $err := printf "ErrEmpty%s" $input }}
+
     // Filter applies the {{ $input }} filter on the {{ $n.QueryName }} builder.
     func (i *{{ $input }}) Filter(q *{{ $n.QueryName }}) (*{{ $n.QueryName }}, error) {
         if i == nil {
@@ -84,10 +86,17 @@ in the LICENSE file in the root directory of this source tree.
         }
         p, err := i.P()
         if err != nil {
+            {{- /* Skip errors only for top-level empty predicates. The rest are invalid. */}}
+            if err == {{ $err }} {
+               return q, nil
+            }
             return nil, err
         }
         return q.Where(p), nil
     }
+
+    // {{ $err }} is returned in case the {{ $input }} is empty.
+    var {{ $err }} = errors.New("{{ base $.Config.Package }}: empty predicate {{ $input }}")
 
     // P returns a predicate for filtering {{ plural $n.Name | lower }}.
     // An error is returned if the input is empty or invalid.
@@ -96,7 +105,7 @@ in the LICENSE file in the root directory of this source tree.
         if i.Not != nil {
             p, err := i.Not.P()
             if err != nil {
-                return nil, err
+                return nil, fmt.Errorf("%w: field 'not'", err)
             }
             predicates = append(predicates, {{ $n.Package }}.Not(p))
         }
@@ -104,7 +113,7 @@ in the LICENSE file in the root directory of this source tree.
         case n == 1:
             p, err := i.Or[0].P()
             if err != nil {
-                return nil, err
+                return nil, fmt.Errorf("%w: field 'or'", err)
             }
             predicates = append(predicates, p)
         case n > 1:
@@ -112,7 +121,7 @@ in the LICENSE file in the root directory of this source tree.
             for _, w := range i.Or {
                 p, err := w.P()
                 if err != nil {
-                    return nil, err
+                    return nil, fmt.Errorf("%w: field 'or'", err)
                 }
                 or = append(or, p)
             }
@@ -122,7 +131,7 @@ in the LICENSE file in the root directory of this source tree.
         case n == 1:
             p, err := i.And[0].P()
             if err != nil {
-                return nil, err
+                return nil, fmt.Errorf("%w: field 'and'", err)
             }
             predicates = append(predicates, p)
         case n > 1:
@@ -130,7 +139,7 @@ in the LICENSE file in the root directory of this source tree.
             for _, w := range i.And {
                 p, err := w.P()
                 if err != nil {
-                    return nil, err
+                    return nil, fmt.Errorf("%w: field 'and'", err)
                 }
                 and = append(and, p)
             }
@@ -177,7 +186,7 @@ in the LICENSE file in the root directory of this source tree.
                 for _, w := range i.{{ $func }} {
                     p, err := w.P()
                     if err != nil {
-                        return nil, err
+                        return nil, fmt.Errorf("%w: field '{{ $func }}'", err)
                     }
                     with = append(with, p)
                 }
@@ -186,7 +195,7 @@ in the LICENSE file in the root directory of this source tree.
         {{- end }}
         switch len(predicates) {
         case 0:
-            return nil, fmt.Errorf("empty predicate {{ $input }}")
+            return nil, {{ $err }}
         case 1:
             return predicates[0], nil
         default:


### PR DESCRIPTION
Passing empty `not`, `and`, etc is invalid. 