### PR TITLE
entgql: fixed cursor type in nested pagination

### DIFF
--- a/entgql/internal/todo/ent/gql_collection.go
+++ b/entgql/internal/todo/ent/gql_collection.go
@@ -784,7 +784,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {

--- a/entgql/internal/todofed/ent/gql_collection.go
+++ b/entgql/internal/todofed/ent/gql_collection.go
@@ -262,7 +262,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {

--- a/entgql/internal/todogotype/ent/gql_collection.go
+++ b/entgql/internal/todogotype/ent/gql_collection.go
@@ -831,7 +831,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {

--- a/entgql/internal/todopulid/ent/gql_collection.go
+++ b/entgql/internal/todopulid/ent/gql_collection.go
@@ -785,7 +785,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {

--- a/entgql/internal/todouuid/ent/gql_collection.go
+++ b/entgql/internal/todouuid/ent/gql_collection.go
@@ -785,7 +785,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -245,7 +245,7 @@ func unmarshalArgs(ctx context.Context, whereInput interface{}, args map[string]
 		}
 		c := &Cursor{}
 		if c.UnmarshalGQL(v) == nil {
-			args[k] = &c
+			args[k] = c
 		}
 	}
 	if v, ok := args[whereField]; ok && whereInput != nil {


### PR DESCRIPTION
Fixed
```sh
interface conversion: interface {} is **ent.Cursor, not *ent.Cursor
```