### PR TITLE
entgql: Use nil to check that a generated enum satisfies interface 

### DIFF
--- a/entgql/template/enum.tmpl
+++ b/entgql/template/enum.tmpl
@@ -31,7 +31,7 @@ in the LICENSE file in the root directory of this source tree.
 	{{- else }}
 		var (
 			// {{ $enum }} must implement graphql.Marshaler.
-			_ graphql.Marshaler = {{ $enum }}("")
+			 _ graphql.Marshaler = (*{{ $enum }})(nil)
 			// {{ $enum }} must implement graphql.Unmarshaler.
 			 _ graphql.Unmarshaler = (*{{ $enum }})(nil)
 		)


### PR DESCRIPTION
Fixes https://github.com/ent/ent/issues/2517

Changes the interface check from trying to instantiate a string enum to checking the nil pointer type. 