### PR TITLE
feat(entgql): support child value list for directive annotation

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -59,9 +59,10 @@ type (
 
 	// DirectiveArgument return a GraphQL directive argument
 	DirectiveArgument struct {
-		Name  string        `json:"name,omitempty"`
-		Value string        `json:"value,omitempty"`
-		Kind  ast.ValueKind `json:"kind,omitempty"`
+		Name     string             `json:"name,omitempty"`
+		Children ast.ChildValueList `json:"children,omitempty"`
+		Value    string             `json:"value,omitempty"`
+		Kind     ast.ValueKind      `json:"kind,omitempty"`
 	}
 
 	// SkipMode is a bit flag for the Skip annotation.
@@ -512,6 +513,23 @@ func NewDirective(name string, args ...DirectiveArgument) Directive {
 		Name:      name,
 		Arguments: args,
 	}
+}
+
+func DirectiveChildren(s []string) ast.ChildValueList {
+	var list ast.ChildValueList
+
+	for _, v := range s {
+		child := &ast.ChildValue{
+			Value: &ast.Value{
+				Raw:  v,
+				Kind: ast.StringValue,
+			},
+		}
+
+		list = append(list, child)
+	}
+
+	return list
 }
 
 // Deprecated create `@deprecated` directive to apply on the field/type

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -53,16 +53,8 @@ type (
 
 	// Directive to apply on the field/type.
 	Directive struct {
-		Name      string              `json:"name,omitempty"`
-		Arguments []DirectiveArgument `json:"arguments,omitempty"`
-	}
-
-	// DirectiveArgument return a GraphQL directive argument
-	DirectiveArgument struct {
-		Name     string             `json:"name,omitempty"`
-		Children ast.ChildValueList `json:"children,omitempty"`
-		Value    string             `json:"value,omitempty"`
-		Kind     ast.ValueKind      `json:"kind,omitempty"`
+		Name      string          `json:"name,omitempty"`
+		Arguments []*ast.Argument `json:"arguments,omitempty"`
 	}
 
 	// SkipMode is a bit flag for the Skip annotation.
@@ -508,39 +500,23 @@ var (
 
 // NewDirective returns a GraphQL directive
 // to use with the entgql.Directives annotation.
-func NewDirective(name string, args ...DirectiveArgument) Directive {
+func NewDirective(name string, args ...*ast.Argument) Directive {
 	return Directive{
 		Name:      name,
 		Arguments: args,
 	}
 }
 
-// DirectiveListArgument returns an argument with the list of values.
-func DirectiveListArgument(name string, kind ast.ValueKind, rawValues ...string) DirectiveArgument {
-	list := make(ast.ChildValueList, len(rawValues))
-	for i, v := range rawValues {
-		list[i] = &ast.ChildValue{
-			Value: &ast.Value{
-				Raw:  v,
-				Kind: kind,
-			},
-		}
-	}
-	return DirectiveArgument{
-		Children: list,
-		Kind:     ast.ListValue,
-		Name:     name,
-	}
-}
-
 // Deprecated create `@deprecated` directive to apply on the field/type
 func Deprecated(reason string) Directive {
-	var args []DirectiveArgument
+	var args []*ast.Argument
 	if reason != "" {
-		args = append(args, DirectiveArgument{
-			Name:  "reason",
-			Kind:  ast.StringValue,
-			Value: reason,
+		args = append(args, &ast.Argument{
+			Name: "reason",
+			Value: &ast.Value{
+				Raw:  reason,
+				Kind: ast.StringValue,
+			},
 		})
 	}
 	return NewDirective("deprecated", args...)

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -515,22 +515,23 @@ func NewDirective(name string, args ...DirectiveArgument) Directive {
 	}
 }
 
-// DirectiveChildren returns a ChildValueList for the directive.
-func DirectiveChildren(k ast.ValueKind, s []string) ast.ChildValueList {
-	var list ast.ChildValueList
 
-	for _, v := range s {
-		child := &ast.ChildValue{
+// DirectiveListArgument returns an argument with the list of values.
+func DirectiveListArgument(name string, kind ast.ValueKind, rawValues ...string) DirectiveArgument {
+	list := make(ast.ChildValueList, len(rawValues))
+	for i, v := range rawValues {
+		list[i] = &ast.ChildValue{
 			Value: &ast.Value{
 				Raw:  v,
-				Kind: k,
+				Kind: kind,
 			},
 		}
-
-		list = append(list, child)
 	}
-
-	return list
+	return DirectiveArgument{
+		Children: list,
+		Kind:     ast.ListValue,
+		Name:     name,
+	}
 }
 
 // Deprecated create `@deprecated` directive to apply on the field/type

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -515,7 +515,6 @@ func NewDirective(name string, args ...DirectiveArgument) Directive {
 	}
 }
 
-
 // DirectiveListArgument returns an argument with the list of values.
 func DirectiveListArgument(name string, kind ast.ValueKind, rawValues ...string) DirectiveArgument {
 	list := make(ast.ChildValueList, len(rawValues))

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -515,14 +515,15 @@ func NewDirective(name string, args ...DirectiveArgument) Directive {
 	}
 }
 
-func DirectiveChildren(s []string) ast.ChildValueList {
+// DirectiveChildren returns a ChildValueList for the directive.
+func DirectiveChildren(k ast.ValueKind, s []string) ast.ChildValueList {
 	var list ast.ChildValueList
 
 	for _, v := range s {
 		child := &ast.ChildValue{
 			Value: &ast.Value{
 				Raw:  v,
-				Kind: ast.StringValue,
+				Kind: k,
 			},
 		}
 

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -19,6 +19,7 @@ import (
 
 	"entgo.io/contrib/entgql"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 func TestAnnotation(t *testing.T) {
@@ -60,4 +61,33 @@ func TestAnnotationDecode(t *testing.T) {
 	err = ann.Decode("invalid")
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type entgql.Annotation")
+}
+
+func TestDirectiveChildren(t *testing.T) {
+	t.Parallel()
+
+	expected := ast.ChildValueList{
+		&ast.ChildValue{
+			Value: &ast.Value{
+				Raw:  "foo",
+				Kind: ast.StringValue,
+			},
+		},
+		&ast.ChildValue{
+			Value: &ast.Value{
+				Raw:  "bar",
+				Kind: ast.StringValue,
+			},
+		},
+		&ast.ChildValue{
+			Value: &ast.Value{
+				Raw:  "baz",
+				Kind: ast.StringValue,
+			},
+		},
+	}
+
+	actual := entgql.DirectiveChildren([]string{"foo", "bar", "baz"})
+
+	require.Equal(t, expected, actual)
 }

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -19,7 +19,6 @@ import (
 
 	"entgo.io/contrib/entgql"
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/v2/ast"
 )
 
 func TestAnnotation(t *testing.T) {
@@ -61,20 +60,4 @@ func TestAnnotationDecode(t *testing.T) {
 	err = ann.Decode("invalid")
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type entgql.Annotation")
-}
-
-func TestDirectiveListArgument(t *testing.T) {
-	t.Parallel()
-	expected := entgql.DirectiveArgument{
-		Name: "foo",
-		Kind: ast.ListValue,
-		Children: ast.ChildValueList{
-			&ast.ChildValue{Value: &ast.Value{Raw: "bar", Kind: ast.StringValue}},
-			&ast.ChildValue{Value: &ast.Value{Raw: "baz", Kind: ast.StringValue}},
-		},
-	}
-	arg := entgql.DirectiveListArgument("foo", ast.StringValue, "bar", "baz")
-	require.Equal(t, expected.Name, arg.Name)
-	require.Equal(t, expected.Kind, arg.Kind)
-	require.Equal(t, expected.Children, arg.Children)
 }

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -87,7 +87,7 @@ func TestDirectiveChildren(t *testing.T) {
 		},
 	}
 
-	actual := entgql.DirectiveChildren([]string{"foo", "bar", "baz"})
+	actual := entgql.DirectiveChildren(ast.StringValue, []string{"foo", "bar", "baz"})
 
 	require.Equal(t, expected, actual)
 }

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -63,31 +63,18 @@ func TestAnnotationDecode(t *testing.T) {
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type entgql.Annotation")
 }
 
-func TestDirectiveChildren(t *testing.T) {
+func TestDirectiveListArgument(t *testing.T) {
 	t.Parallel()
-
-	expected := ast.ChildValueList{
-		&ast.ChildValue{
-			Value: &ast.Value{
-				Raw:  "foo",
-				Kind: ast.StringValue,
-			},
-		},
-		&ast.ChildValue{
-			Value: &ast.Value{
-				Raw:  "bar",
-				Kind: ast.StringValue,
-			},
-		},
-		&ast.ChildValue{
-			Value: &ast.Value{
-				Raw:  "baz",
-				Kind: ast.StringValue,
-			},
+	expected := entgql.DirectiveArgument{
+		Name: "foo",
+		Kind: ast.ListValue,
+		Children: ast.ChildValueList{
+			&ast.ChildValue{Value: &ast.Value{Raw: "bar", Kind: ast.StringValue}},
+			&ast.ChildValue{Value: &ast.Value{Raw: "baz", Kind: ast.StringValue}},
 		},
 	}
-
-	actual := entgql.DirectiveChildren(ast.StringValue, []string{"foo", "bar", "baz"})
-
-	require.Equal(t, expected, actual)
+	arg := entgql.DirectiveListArgument("foo", ast.StringValue, "bar", "baz")
+	require.Equal(t, expected.Name, arg.Name)
+	require.Equal(t, expected.Kind, arg.Kind)
+	require.Equal(t, expected.Children, arg.Children)
 }

--- a/entgql/internal/todo/ent.graphql
+++ b/entgql/internal/todo/ent.graphql
@@ -180,7 +180,7 @@ input FriendshipWhereInput {
   createdAtLT: Time
   createdAtLTE: Time
 }
-type Group implements Node {
+type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users(

--- a/entgql/internal/todo/ent/schema/annotation/has_permissions.go
+++ b/entgql/internal/todo/ent/schema/annotation/has_permissions.go
@@ -20,9 +20,8 @@ import (
 )
 
 func HasPermissions(permissions []string) entgql.Directive {
-	return entgql.NewDirective("hasPermissions", entgql.DirectiveArgument{
-		Name:     "permissions",
-		Kind:     ast.ListValue,
-		Children: entgql.DirectiveChildren(ast.StringValue, permissions),
-	})
+	return entgql.NewDirective(
+		"hasPermissions",
+		entgql.DirectiveListArgument("permissions", ast.StringValue, permissions...),
+	)
 }

--- a/entgql/internal/todo/ent/schema/annotation/has_permissions.go
+++ b/entgql/internal/todo/ent/schema/annotation/has_permissions.go
@@ -20,8 +20,23 @@ import (
 )
 
 func HasPermissions(permissions []string) entgql.Directive {
+	children := make(ast.ChildValueList, 0, len(permissions))
+	for _, p := range permissions {
+		children = append(children, &ast.ChildValue{
+			Value: &ast.Value{
+				Raw:  p,
+				Kind: ast.StringValue,
+			},
+		})
+	}
 	return entgql.NewDirective(
 		"hasPermissions",
-		entgql.DirectiveListArgument("permissions", ast.StringValue, permissions...),
+		&ast.Argument{
+			Name: "permissions",
+			Value: &ast.Value{
+				Children: children,
+				Kind:     ast.ListValue,
+			},
+		},
 	)
 }

--- a/entgql/internal/todo/ent/schema/annotation/has_permissions.go
+++ b/entgql/internal/todo/ent/schema/annotation/has_permissions.go
@@ -23,6 +23,6 @@ func HasPermissions(permissions []string) entgql.Directive {
 	return entgql.NewDirective("hasPermissions", entgql.DirectiveArgument{
 		Name:     "permissions",
 		Kind:     ast.ListValue,
-		Children: entgql.DirectiveChildren(permissions),
+		Children: entgql.DirectiveChildren(ast.StringValue, permissions),
 	})
 }

--- a/entgql/internal/todo/ent/schema/annotation/has_permissions.go
+++ b/entgql/internal/todo/ent/schema/annotation/has_permissions.go
@@ -12,23 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package todo
+package annotation
 
 import (
-	"entgo.io/contrib/entgql/internal/todo"
-	"entgo.io/contrib/entgql/internal/todouuid/ent"
-	"github.com/99designs/gqlgen/graphql"
+	"entgo.io/contrib/entgql"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
-// Resolver is the resolver root.
-type Resolver struct{ client *ent.Client }
-
-// NewSchema creates a graphql executable schema.
-func NewSchema(client *ent.Client) graphql.ExecutableSchema {
-	return NewExecutableSchema(Config{
-		Resolvers: &Resolver{client},
-		Directives: DirectiveRoot{
-			HasPermissions: todo.HasPermission(),
-		},
+func HasPermissions(permissions []string) entgql.Directive {
+	return entgql.NewDirective("hasPermissions", entgql.DirectiveArgument{
+		Name:     "permissions",
+		Kind:     ast.ListValue,
+		Children: entgql.DirectiveChildren(permissions),
 	})
 }

--- a/entgql/internal/todo/ent/schema/group.go
+++ b/entgql/internal/todo/ent/schema/group.go
@@ -16,6 +16,7 @@ package schema
 
 import (
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todo/ent/schema/annotation"
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/edge"
@@ -49,5 +50,8 @@ func (Group) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.Directives(
+			annotation.HasPermissions([]string{"ADMIN", "MODERATOR"}),
+		),
 	}
 }

--- a/entgql/internal/todo/generated.go
+++ b/entgql/internal/todo/generated.go
@@ -47,6 +47,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	HasPermissions func(ctx context.Context, obj interface{}, next graphql.Resolver, permissions []string) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {
@@ -730,7 +731,9 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "todo.graphql", Input: `type CategoryConfig {
+	{Name: "todo.graphql", Input: `directive @hasPermissions(permissions: [String!]!) on OBJECT | FIELD_DEFINITION
+
+type CategoryConfig {
   maxMembers: Int
 }
 
@@ -942,7 +945,7 @@ input FriendshipWhereInput {
   createdAtLT: Time
   createdAtLTE: Time
 }
-type Group implements Node {
+type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users(
@@ -1355,6 +1358,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) dir_hasPermissions_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []string
+	if tmp, ok := rawArgs["permissions"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissions"))
+		arg0, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["permissions"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Category_todos_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -2839,8 +2857,32 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return obj.Node, nil
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			permissions, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"ADMIN", "MODERATOR"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasPermissions == nil {
+				return nil, errors.New("directive hasPermissions is not implemented")
+			}
+			return ec.directives.HasPermissions(ctx, obj, directive0, permissions)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*ent.Group); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *entgo.io/contrib/entgql/internal/todo/ent.Group`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10137,6 +10179,38 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/entgql/internal/todo/has_permission.go
+++ b/entgql/internal/todo/has_permission.go
@@ -15,20 +15,19 @@
 package todo
 
 import (
-	"entgo.io/contrib/entgql/internal/todo"
-	"entgo.io/contrib/entgql/internal/todouuid/ent"
+	"context"
+
 	"github.com/99designs/gqlgen/graphql"
 )
 
-// Resolver is the resolver root.
-type Resolver struct{ client *ent.Client }
-
-// NewSchema creates a graphql executable schema.
-func NewSchema(client *ent.Client) graphql.ExecutableSchema {
-	return NewExecutableSchema(Config{
-		Resolvers: &Resolver{client},
-		Directives: DirectiveRoot{
-			HasPermissions: todo.HasPermission(),
-		},
-	})
+func HasPermission() func(context.Context, interface{}, graphql.Resolver, []string) (interface{}, error) {
+	return func(
+		ctx context.Context,
+		obj interface{},
+		next graphql.Resolver,
+		permissions []string,
+	) (res interface{}, err error) {
+		// you can do your thing here for permissions
+		return next(ctx)
+	}
 }

--- a/entgql/internal/todo/resolver.go
+++ b/entgql/internal/todo/resolver.go
@@ -26,5 +26,8 @@ type Resolver struct{ client *ent.Client }
 func NewSchema(client *ent.Client) graphql.ExecutableSchema {
 	return NewExecutableSchema(Config{
 		Resolvers: &Resolver{client},
+		Directives: DirectiveRoot{
+			HasPermissions: HasPermission(),
+		},
 	})
 }

--- a/entgql/internal/todo/todo.graphql
+++ b/entgql/internal/todo/todo.graphql
@@ -1,3 +1,5 @@
+directive @hasPermissions(permissions: [String!]!) on OBJECT | FIELD_DEFINITION
+
 type CategoryConfig {
   maxMembers: Int
 }

--- a/entgql/internal/todogotype/generated.go
+++ b/entgql/internal/todogotype/generated.go
@@ -51,6 +51,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	HasPermissions func(ctx context.Context, obj interface{}, next graphql.Resolver, permissions []string) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {
@@ -748,7 +749,9 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "../todo/todo.graphql", Input: `type CategoryConfig {
+	{Name: "../todo/todo.graphql", Input: `directive @hasPermissions(permissions: [String!]!) on OBJECT | FIELD_DEFINITION
+
+type CategoryConfig {
   maxMembers: Int
 }
 
@@ -960,7 +963,7 @@ input FriendshipWhereInput {
   createdAtLT: Time
   createdAtLTE: Time
 }
-type Group implements Node {
+type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users(
@@ -1373,6 +1376,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) dir_hasPermissions_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []string
+	if tmp, ok := rawArgs["permissions"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissions"))
+		arg0, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["permissions"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Category_todos_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -2857,8 +2875,32 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return obj.Node, nil
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			permissions, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"ADMIN", "MODERATOR"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasPermissions == nil {
+				return nil, errors.New("directive hasPermissions is not implemented")
+			}
+			return ec.directives.HasPermissions(ctx, obj, directive0, permissions)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*ent.Group); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *entgo.io/contrib/entgql/internal/todogotype/ent.Group`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10196,6 +10238,38 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/entgql/internal/todogotype/resolver.go
+++ b/entgql/internal/todogotype/resolver.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"entgo.io/contrib/entgql/internal/todo"
 	"entgo.io/contrib/entgql/internal/todogotype/ent"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -35,6 +36,9 @@ type Resolver struct{ client *ent.Client }
 func NewSchema(client *ent.Client) graphql.ExecutableSchema {
 	return NewExecutableSchema(Config{
 		Resolvers: &Resolver{client},
+		Directives: DirectiveRoot{
+			HasPermissions: todo.HasPermission(),
+		},
 	})
 }
 

--- a/entgql/internal/todopulid/resolver.go
+++ b/entgql/internal/todopulid/resolver.go
@@ -15,6 +15,7 @@
 package todopulid
 
 import (
+	"entgo.io/contrib/entgql/internal/todo"
 	"entgo.io/contrib/entgql/internal/todopulid/ent"
 	"github.com/99designs/gqlgen/graphql"
 )
@@ -26,5 +27,8 @@ type Resolver struct{ client *ent.Client }
 func NewSchema(client *ent.Client) graphql.ExecutableSchema {
 	return NewExecutableSchema(Config{
 		Resolvers: &Resolver{client},
+		Directives: DirectiveRoot{
+			HasPermissions: todo.HasPermission(),
+		},
 	})
 }

--- a/entgql/internal/todouuid/generated.go
+++ b/entgql/internal/todouuid/generated.go
@@ -52,6 +52,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	HasPermissions func(ctx context.Context, obj interface{}, next graphql.Resolver, permissions []string) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {
@@ -749,7 +750,9 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "../todo/todo.graphql", Input: `type CategoryConfig {
+	{Name: "../todo/todo.graphql", Input: `directive @hasPermissions(permissions: [String!]!) on OBJECT | FIELD_DEFINITION
+
+type CategoryConfig {
   maxMembers: Int
 }
 
@@ -961,7 +964,7 @@ input FriendshipWhereInput {
   createdAtLT: Time
   createdAtLTE: Time
 }
-type Group implements Node {
+type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users(
@@ -1374,6 +1377,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) dir_hasPermissions_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []string
+	if tmp, ok := rawArgs["permissions"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permissions"))
+		arg0, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["permissions"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Category_todos_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -2858,8 +2876,32 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return obj.Node, nil
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			permissions, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"ADMIN", "MODERATOR"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasPermissions == nil {
+				return nil, errors.New("directive hasPermissions is not implemented")
+			}
+			return ec.directives.HasPermissions(ctx, obj, directive0, permissions)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*ent.Group); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *entgo.io/contrib/entgql/internal/todouuid/ent.Group`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10187,6 +10229,38 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -361,14 +361,7 @@ func (e *schemaGenerator) buildDirectives(directives []Directive) ast.DirectiveL
 	for _, d := range directives {
 		args := make(ast.ArgumentList, 0, len(d.Arguments))
 		for _, a := range d.Arguments {
-			args = append(args, &ast.Argument{
-				Name: a.Name,
-				Value: &ast.Value{
-					Raw:      a.Value,
-					Children: a.Children,
-					Kind:     a.Kind,
-				},
-			})
+			args = append(args, a)
 		}
 		list = append(list, &ast.Directive{
 			Name:      d.Name,

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -359,13 +359,9 @@ func (e *schemaGenerator) buildType(t *gen.Type, ant *Annotation, gqlType, pkg s
 func (e *schemaGenerator) buildDirectives(directives []Directive) ast.DirectiveList {
 	list := make(ast.DirectiveList, 0, len(directives))
 	for _, d := range directives {
-		args := make(ast.ArgumentList, 0, len(d.Arguments))
-		for _, a := range d.Arguments {
-			args = append(args, a)
-		}
 		list = append(list, &ast.Directive{
 			Name:      d.Name,
-			Arguments: args,
+			Arguments: d.Arguments,
 		})
 	}
 	return list

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -364,8 +364,9 @@ func (e *schemaGenerator) buildDirectives(directives []Directive) ast.DirectiveL
 			args = append(args, &ast.Argument{
 				Name: a.Name,
 				Value: &ast.Value{
-					Raw:  a.Value,
-					Kind: a.Kind,
+					Raw:      a.Value,
+					Children: a.Children,
+					Kind:     a.Kind,
 				},
 			})
 		}

--- a/entgql/schema_test.go
+++ b/entgql/schema_test.go
@@ -96,7 +96,7 @@ type Friendship {
   user: User!
   friend: User!
 }
-type Group {
+type Group @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users: [User!]
@@ -366,7 +366,7 @@ input FriendshipWhereInput {
   createdAtLT: Time
   createdAtLTE: Time
 }
-type Group implements Node {
+type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
   id: ID!
   name: String!
   users(


### PR DESCRIPTION
Hi 👋 That's my first time contributing to `Ent` and I must say I'm enjoying it so far.

This PR allows the creation of a directive annotation using a child value list, for example:

```
directive @hasPermissions(permissions: [String!]!) on OBJECT | FIELD_DEFINITION
```

The original implementation only allowed the user to specify a `string` as a value:

https://github.com/ent/contrib/blob/462c4e5698731377eb38f5a61b16518bb7295341/entgql/annotation.go#L61-L65

https://github.com/ent/contrib/blob/462c4e5698731377eb38f5a61b16518bb7295341/entgql/annotation.go#L518-L528

Now you can specify a child value list:

```golang
func HasPermissions(permissions []string) entgql.Directive {
	return entgql.NewDirective("hasPermissions", entgql.DirectiveArgument{
		Name:     "permissions",
		Kind:     ast.ListValue,
		Children: entgql.DirectiveChildren(permissions),
	})
}
```

The `entgql.DirectiveChildren` is a function that coverts a slice of `string` to `ast.ChildValueList`.

You can use it like this:

```golang
// Annotations returns Group annotations.
func (Group) Annotations() []schema.Annotation {
	return []schema.Annotation{
		entgql.RelayConnection(),
		entgql.QueryField(),
		entgql.Directives(
			annotation.HasPermissions([]string{"ADMIN", "MODERATOR"}),
		),
	}
}
```

The result will be on your `ent.graphql`:

```graphql
type Group implements Node @hasPermissions(permissions: ["ADMIN","MODERATOR"]) {
```

I'm also accepting suggestions for the `entgql.DirectiveChildren` function name if you don't like it.

Thank you.