### PR TITLE
entgql: accept non-gql context in generated edge methods

### DIFF
--- a/entgql/internal/todo/ent/gql_edge.go
+++ b/entgql/internal/todo/ent/gql_edge.go
@@ -136,16 +136,24 @@ func (u *User) Groups(
 	return u.QueryGroups().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) Friends(ctx context.Context) ([]*User, error) {
-	result, err := u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friends(ctx context.Context) (result []*User, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriends().All(ctx)
 	}
 	return result, err
 }
 
-func (u *User) Friendships(ctx context.Context) ([]*Friendship, error) {
-	result, err := u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friendships(ctx context.Context) (result []*Friendship, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendshipsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriendships().All(ctx)
 	}

--- a/entgql/internal/todofed/ent/gql_edge.go
+++ b/entgql/internal/todofed/ent/gql_edge.go
@@ -22,8 +22,12 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 )
 
-func (c *Category) Todos(ctx context.Context) ([]*Todo, error) {
-	result, err := c.NamedTodos(graphql.GetFieldContext(ctx).Field.Alias)
+func (c *Category) Todos(ctx context.Context) (result []*Todo, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = c.NamedTodos(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = c.Edges.TodosOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = c.QueryTodos().All(ctx)
 	}
@@ -38,8 +42,12 @@ func (t *Todo) Parent(ctx context.Context) (*Todo, error) {
 	return result, MaskNotFound(err)
 }
 
-func (t *Todo) Children(ctx context.Context) ([]*Todo, error) {
-	result, err := t.NamedChildren(graphql.GetFieldContext(ctx).Field.Alias)
+func (t *Todo) Children(ctx context.Context) (result []*Todo, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = t.NamedChildren(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = t.Edges.ChildrenOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = t.QueryChildren().All(ctx)
 	}

--- a/entgql/internal/todogotype/ent/gql_edge.go
+++ b/entgql/internal/todogotype/ent/gql_edge.go
@@ -136,16 +136,24 @@ func (u *User) Groups(
 	return u.QueryGroups().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) Friends(ctx context.Context) ([]*User, error) {
-	result, err := u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friends(ctx context.Context) (result []*User, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriends().All(ctx)
 	}
 	return result, err
 }
 
-func (u *User) Friendships(ctx context.Context) ([]*Friendship, error) {
-	result, err := u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friendships(ctx context.Context) (result []*Friendship, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendshipsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriendships().All(ctx)
 	}

--- a/entgql/internal/todopulid/ent/gql_edge.go
+++ b/entgql/internal/todopulid/ent/gql_edge.go
@@ -136,16 +136,24 @@ func (u *User) Groups(
 	return u.QueryGroups().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) Friends(ctx context.Context) ([]*User, error) {
-	result, err := u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friends(ctx context.Context) (result []*User, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriends().All(ctx)
 	}
 	return result, err
 }
 
-func (u *User) Friendships(ctx context.Context) ([]*Friendship, error) {
-	result, err := u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friendships(ctx context.Context) (result []*Friendship, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendshipsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriendships().All(ctx)
 	}

--- a/entgql/internal/todouuid/ent/gql_edge.go
+++ b/entgql/internal/todouuid/ent/gql_edge.go
@@ -136,16 +136,24 @@ func (u *User) Groups(
 	return u.QueryGroups().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) Friends(ctx context.Context) ([]*User, error) {
-	result, err := u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friends(ctx context.Context) (result []*User, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriends(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriends().All(ctx)
 	}
 	return result, err
 }
 
-func (u *User) Friendships(ctx context.Context) ([]*Friendship, error) {
-	result, err := u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+func (u *User) Friendships(ctx context.Context) (result []*Friendship, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = u.NamedFriendships(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = u.Edges.FriendshipsOrErr()
+	}
 	if IsNotLoaded(err) {
 		result, err = u.QueryFriendships().All(ctx)
 	}

--- a/entgql/template/edge.tmpl
+++ b/entgql/template/edge.tmpl
@@ -19,8 +19,13 @@ import "context"
 				{{ template "gql_edge/helper/paginate" . }}
 			{{ end }}
 		{{ else if not $e.Unique }}
-			func ({{ $r }} *{{ $n.Name }}) {{ $e.StructField }}(ctx context.Context) ([]*{{ $e.Type.Name }}, error) {
-				result, err := {{ $r }}.Named{{ $e.StructField }}(graphql.GetFieldContext(ctx).Field.Alias)
+			func ({{ $r }} *{{ $n.Name }}) {{ $e.StructField }}(ctx context.Context) (result []*{{ $e.Type.Name }}, err error) {
+				if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+					result, err = {{ $r }}.Named{{ $e.StructField }}(graphql.GetFieldContext(ctx).Field.Alias)
+				} else {
+					{{- /* For regular edges (not Relay connections), we fallback to .Edges field in case the context is not GraphQL */}}
+					result, err = {{ $r }}.Edges.{{ $e.StructField }}OrErr()
+				}
 				if IsNotLoaded(err) {
 					result, err = {{ $r }}.Query{{ $e.StructField }}().All(ctx)
 				}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/go-faster/jx v0.25.0 // indirect
 	github.com/goccy/go-yaml v1.9.4 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/addlicense v1.0.0 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -91,6 +93,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/addlicense v1.0.0 h1:cqvo5suPWlsk6r6o42Fs2K66xYCl2tnhVPUYoP3EnO4=
+github.com/google/addlicense v1.0.0/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
In case the context is non-gql, we fllback to the regular eager-loading flow (i.e. With<E>)