### PR TITLE
schemast: fix support for generating JSON fields (#3005)

### DIFF
--- a/schemast/field.go
+++ b/schemast/field.go
@@ -44,7 +44,15 @@ func Field(desc *field.Descriptor) (*ast.CallExpr, error) {
 				},
 			))
 	case t == field.TypeJSON:
-		exp, err := parser.ParseExpr("struct{}{}")
+		expr := "struct{}{}"
+		if desc.Info != nil && desc.Info.RType != nil {
+			expr = desc.Info.RType.Ident + "{}"
+			if desc.Info.RType.Kind == reflect.Pointer {
+				expr = "&" + expr
+			}
+		}
+
+		exp, err := parser.ParseExpr(expr)
 		if err != nil {
 			return nil, fmt.Errorf("schemast: json field %s generation error %w", desc.Name, err)
 		}
@@ -147,7 +155,22 @@ func fromComplexType(desc *field.Descriptor, filedType ast.Expr) (*ast.CallExpr,
 		return nil, err
 	}
 
-	call.Args = append(call.Args, filedType)
+	var callExpr = call
+	// Loop through calls to find the base and append the filedType there
+	for {
+		if selectExpr, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+			if prevExpr, ok := selectExpr.X.(*ast.CallExpr); ok {
+				callExpr = prevExpr
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	// Append the filedType to the args of the initial *ast.CallExpr
+	callExpr.Args = append(callExpr.Args, filedType)
 	return call, nil
 }
 

--- a/schemast/field.go
+++ b/schemast/field.go
@@ -51,7 +51,6 @@ func Field(desc *field.Descriptor) (*ast.CallExpr, error) {
 				expr = "&" + expr
 			}
 		}
-
 		exp, err := parser.ParseExpr(expr)
 		if err != nil {
 			return nil, fmt.Errorf("schemast: json field %s generation error %w", desc.Name, err)
@@ -168,7 +167,6 @@ func fromComplexType(desc *field.Descriptor, filedType ast.Expr) (*ast.CallExpr,
 			break
 		}
 	}
-
 	// Append the filedType to the args of the initial *ast.CallExpr
 	callExpr.Args = append(callExpr.Args, filedType)
 	return call, nil

--- a/schemast/field_test.go
+++ b/schemast/field_test.go
@@ -57,6 +57,11 @@ func TestFromFieldDescriptor(t *testing.T) {
 			expected: `field.JSON("json_field", struct{}{})`,
 		},
 		{
+			name:     "json complex",
+			field:    field.JSON("json_complex_field", &entproto.Adapter{}).Optional().Comment("test comment"),
+			expected: `field.JSON("json_complex_field", &entproto.Adapter{}).Optional().Comment("test comment")`,
+		},
+		{
 			name:     "time",
 			field:    field.Time("time").Default(time.Now),
 			expected: `field.Time("time").Default(time.Now)`,

--- a/schemast/mutate.go
+++ b/schemast/mutate.go
@@ -65,6 +65,12 @@ func (u *UpsertSchema) Mutate(ctx *Context) error {
 		if fld.Descriptor().Info.Type == field.TypeUUID {
 			ctx.appendImport(u.Name, "github.com/google/uuid")
 		}
+		// Append any imported struct for JSON fields
+		if fld.Descriptor().Info.Type == field.TypeJSON {
+			if fld.Descriptor().Info.RType != nil && fld.Descriptor().Info.RType.PkgPath != "" {
+				ctx.appendImport(u.Name, fld.Descriptor().Info.RType.PkgPath)
+			}
+		}
 	}
 	for _, edg := range u.Edges {
 		if err := ctx.AppendEdge(u.Name, edg.Descriptor()); err != nil {


### PR DESCRIPTION
* Support custom structs for JSON Fields
* Add Args to the base call instead of the final one
* Append any necessary imports for the struct