### PR TITLE
schemast: Support providing a base schema for a type

### DIFF
--- a/schemast/internal/mutatetest/baseschema.go
+++ b/schemast/internal/mutatetest/baseschema.go
@@ -1,0 +1,22 @@
+package mutatetest
+
+import (
+	"entgo.io/contrib/schemast/internal/mutatetest/mixin"
+	"entgo.io/contrib/schemast/internal/mutatetest/policy"
+	"entgo.io/ent"
+)
+
+// TestBaseSchema is a test base schema
+type TestBaseSchema struct {
+	ent.Schema
+}
+
+func (TestBaseSchema) Mixin() []ent.Mixin {
+	return []ent.Mixin{
+		mixin.UUID{},
+	}
+}
+
+func (TestBaseSchema) Policy() ent.Policy {
+	return policy.IDFilterRule()
+}

--- a/schemast/internal/mutatetest/mixin/mixintest.go
+++ b/schemast/internal/mutatetest/mixin/mixintest.go
@@ -1,0 +1,24 @@
+package mixin
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/mixin"
+	"github.com/google/uuid"
+)
+
+// UUID defines the id field as a UUID string.
+type UUID struct {
+	mixin.Schema
+}
+
+// Fields of the UUID.
+func (UUID) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("id").
+			DefaultFunc(uuid.NewString).
+			NotEmpty().
+			Immutable().
+			Unique(),
+	}
+}

--- a/schemast/internal/mutatetest/policy/policytest.go
+++ b/schemast/internal/mutatetest/policy/policytest.go
@@ -1,0 +1,38 @@
+package policy
+
+import (
+	"context"
+
+	"entgo.io/ent"
+	"entgo.io/ent/privacy"
+)
+
+type (
+	FilterQueryRule func(context.Context, ent.Query) error
+
+	OnlyQuery interface {
+		OnlyID(ctx context.Context) (id string, err error)
+	}
+)
+
+func (f FilterQueryRule) EvalQuery(ctx context.Context, q ent.Query) error {
+	return f(ctx, q)
+}
+
+func (FilterQueryRule) EvalMutation(context.Context, ent.Mutation) error {
+	return nil
+}
+
+func IDFilterRule() ent.Policy {
+	return FilterQueryRule(func(ctx context.Context, q ent.Query) error {
+		IDQuery, ok := q.(OnlyQuery)
+		if ok {
+			_, err := IDQuery.OnlyID(ctx)
+			if err != nil {
+				return privacy.Deny
+			}
+		}
+
+		return privacy.Skip
+	})
+}

--- a/schemast/load.go
+++ b/schemast/load.go
@@ -17,7 +17,6 @@ package schemast
 import (
 	"fmt"
 	"go/ast"
-
 	"golang.org/x/tools/go/packages"
 )
 
@@ -75,6 +74,30 @@ func (c *Context) lookupMethod(typeName string, methodName string) (*ast.FuncDec
 				}
 				if id, ok := fd.Recv.List[0].Type.(*ast.Ident); ok && id.Name == typeName {
 					found = fd
+					return false
+				}
+			}
+			return true
+		})
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// lookupBaseStruct will search the schemast.Context for the AST representing the struct declaration of the requested
+// typeName.
+func (c *Context) lookupBaseStruct(typeName string) (*ast.StructType, bool) {
+	var found *ast.StructType
+	for _, file := range c.syntax() {
+		ast.Inspect(file, func(node ast.Node) bool {
+			if typeSpec, ok := node.(*ast.TypeSpec); ok {
+				if typeSpec.Name.Name != typeName {
+					return true
+				}
+				if structType, ok := typeSpec.Type.(*ast.StructType); ok {
+					found = structType
 					return false
 				}
 			}

--- a/schemast/mutate_test.go
+++ b/schemast/mutate_test.go
@@ -60,6 +60,23 @@ func TestUpsert(t *testing.T) {
 				index.Fields("name"),
 			},
 		},
+		&UpsertSchema{
+			Name: "Group", // A new schema
+			Fields: []ent.Field{
+				field.String("name"),
+			},
+			Edges: []ent.Edge{},
+			Annotations: []schema.Annotation{
+				entproto.Message(),
+			},
+			Indexes: []ent.Index{
+				index.Fields("name"),
+			},
+			BaseConfig: &BaseSchemaConfig{
+				BasePkg:        "entgo.io/contrib/schemast/internal/mutatetest",
+				BaseSchemaType: "mutatetest.TestBaseSchema",
+			},
+		},
 	}
 	err = Mutate(tt.ctx, mutations...)
 	require.NoError(t, err)


### PR DESCRIPTION
* Add AddTypeWithBase method to provide a base schema when adding a type
    * Default AddType will use the ent.Schema
* Add BaseSchemaConfig for UpsertSchema and use AddTypeWithBase if the config is provided
* Unit testing for all of this