### PR TITLE
entgql: return GQLGen response for failure mutation

### DIFF
--- a/entgql/transaction.go
+++ b/entgql/transaction.go
@@ -97,9 +97,7 @@ func (t Transactioner) InterceptResponse(ctx context.Context, next graphql.Respo
 	rsp := next(ctx)
 	if len(rsp.Errors) > 0 {
 		_ = tx.Rollback()
-		return &graphql.Response{
-			Errors: rsp.Errors,
-		}
+		return rsp
 	}
 	if err := tx.Commit(); err != nil {
 		return graphql.ErrorResponse(ctx,


### PR DESCRIPTION
For case the mutation failure with an error.
The mutation name must be present in the response.

The old response
```json
{
  "errors": [
    {
      "message": "not implemented",
      "path": [
        "createTodo"
      ]
    }
  ],
  "data": null
}
```

The new response
```json
{
  "errors": [
    {
      "message": "not implemented",
      "path": [
        "createTodo"
      ]
    }
  ],
  "data": {
    "createTodo": null
  }
}
```

Signed-off-by: Giau. Tran Minh <hello@giautm.dev>