### PR TITLE
entoas: add boundaries for `page` and `itemsPerPage` pagination params

### DIFF
--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -43,6 +43,12 @@ type (
 		// By enabling she SimpleModels configuration the generator simply adds the defined schemas with all fields and edges.
 		// Serialization groups have no effects in this mode.
 		SimpleModels bool
+		// Specify the minimum amount of itemsPerPage allowed in generated pagination.
+		// Defaults to 1.
+		MinItemsPerPage int64
+		// Specify the maximum amount of itemsPerPage allowed in generated pagination.
+		// Defaults to 255.
+		MaxItemsPerPage int64
 	}
 	// Extension implements entc.Extension interface for providing OpenAPI Specification generation.
 	Extension struct {
@@ -60,7 +66,11 @@ type (
 
 // NewExtension returns a new entoas extension with default values.
 func NewExtension(opts ...ExtensionOption) (*Extension, error) {
-	ex := &Extension{config: &Config{DefaultPolicy: PolicyExpose}}
+	ex := &Extension{config: &Config{
+		DefaultPolicy:   PolicyExpose,
+		MinItemsPerPage: one,
+		MaxItemsPerPage: maxu8,
+	}}
 	for _, opt := range opts {
 		if err := opt(ex); err != nil {
 			return nil, err
@@ -83,6 +93,22 @@ func (ex *Extension) Annotations() []entc.Annotation {
 func DefaultPolicy(p Policy) ExtensionOption {
 	return func(ex *Extension) error {
 		ex.config.DefaultPolicy = p
+		return nil
+	}
+}
+
+// MinItemsPerPage sets the minimum value for the 'itemsPerPage' parameter in list pagination.
+func MinItemsPerPage(n int) ExtensionOption {
+	return func(ex *Extension) error {
+		ex.config.MinItemsPerPage = int64(n)
+		return nil
+	}
+}
+
+// MaxItemsPerPage sets the maximum value for the 'itemsPerPage' parameter in list pagination.
+func MaxItemsPerPage(n int) ExtensionOption {
+	return func(ex *Extension) error {
+		ex.config.MaxItemsPerPage = int64(n)
 		return nil
 	}
 }

--- a/entoas/extension_test.go
+++ b/entoas/extension_test.go
@@ -27,6 +27,8 @@ func TestExtension(t *testing.T) {
 	t.Parallel()
 	ex, err := NewExtension(
 		DefaultPolicy(PolicyExpose),
+		MinItemsPerPage(20),
+		MaxItemsPerPage(40),
 		Mutations(func(_ *gen.Graph, spec *ogen.Spec) error {
 			spec.Info.
 				SetTitle("Spec Title").
@@ -39,5 +41,7 @@ func TestExtension(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ex.config.DefaultPolicy, PolicyExpose)
 	require.Len(t, ex.mutations, 1)
-	require.Equal(t, ex.out, os.Stdout)
+	require.Equal(t, os.Stdout, ex.out)
+	require.Equal(t, int64(20), ex.config.MinItemsPerPage)
+	require.Equal(t, int64(40), ex.config.MaxItemsPerPage)
 }

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -420,6 +420,10 @@ func deleteOp(spec *ogen.Spec, n *gen.Type) (*ogen.Operation, error) {
 
 // listOp returns a spec.OperationConfig for a list operation on the given node.
 func listOp(spec *ogen.Spec, n *gen.Type) (*ogen.Operation, error) {
+	cfg, err := GetConfig(n.Config)
+	if err != nil {
+		return nil, err
+	}
 	vn, err := ViewName(n, OpList)
 	if err != nil {
 		return nil, err
@@ -434,12 +438,15 @@ func listOp(spec *ogen.Spec, n *gen.Type) (*ogen.Operation, error) {
 				InQuery().
 				SetName("page").
 				SetDescription("what page to render").
-				SetSchema(ogen.Int()),
+				SetSchema(ogen.Int().SetMinimum(&one)),
 			ogen.NewParameter().
 				InQuery().
 				SetName("itemsPerPage").
 				SetDescription("item count to render per page").
-				SetSchema(ogen.Int()),
+				SetSchema(ogen.Int().
+					SetMinimum(&cfg.MinItemsPerPage).
+					SetMaximum(&cfg.MaxItemsPerPage),
+				),
 		).
 		AddResponse(
 			strconv.Itoa(http.StatusOK),
@@ -513,6 +520,7 @@ func property(f *gen.Field) (*ogen.Property, error) {
 
 var (
 	zero   int64
+	one    int64 = 1
 	min8   int64 = math.MinInt8
 	max8   int64 = math.MaxInt8
 	maxu8  int64 = math.MaxUint8

--- a/entoas/internal/cycle/openapi.json
+++ b/entoas/internal/cycle/openapi.json
@@ -20,7 +20,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -28,7 +29,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],

--- a/entoas/internal/oastypes/openapi.json
+++ b/entoas/internal/oastypes/openapi.json
@@ -20,7 +20,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -28,7 +29,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],

--- a/entoas/internal/pets/openapi.json
+++ b/entoas/internal/pets/openapi.json
@@ -20,7 +20,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -28,7 +29,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],
@@ -339,7 +342,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -347,7 +351,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],
@@ -803,7 +809,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -811,7 +818,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],

--- a/entoas/internal/simple/openapi.json
+++ b/entoas/internal/simple/openapi.json
@@ -20,7 +20,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -28,7 +29,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],
@@ -339,7 +342,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -347,7 +351,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],
@@ -803,7 +809,8 @@
             "in": "query",
             "description": "what page to render",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             }
           },
           {
@@ -811,7 +818,9 @@
             "in": "query",
             "description": "item count to render per page",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "maximum": 255,
+              "minimum": 1
             }
           }
         ],


### PR DESCRIPTION
Ensures the `itemsPerPage` parameter is at least 1 and less than 255. Added the `MinItemsPerPage()` and `MaxItemsPerPage()` options for configuration.