### PR TITLE
entproto: make it possible to configure generated output so that it can work with Buf/Connect

### DIFF
--- a/entproto/adapter.go
+++ b/entproto/adapter.go
@@ -56,19 +56,8 @@ var (
 	}
 )
 
-type (
-	AdapterOption func(*Adapter)
-)
-
-// WithMethodNameSuffix sets the adapter to use the suffix "ent" for all generated methods
-func WithMethodNameSuffix() AdapterOption {
-	return func(a *Adapter) {
-		a.useMethodNameSuffix = true
-	}
-}
-
 // LoadAdapter takes a *gen.Graph and parses it into protobuf file descriptors
-func LoadAdapter(graph *gen.Graph, opts ...AdapterOption) (*Adapter, error) {
+func LoadAdapter(graph *gen.Graph, opts *Options) (*Adapter, error) {
 	a := &Adapter{
 		graph:            graph,
 		descriptors:      make(map[string]*desc.FileDescriptor),
@@ -76,8 +65,10 @@ func LoadAdapter(graph *gen.Graph, opts ...AdapterOption) (*Adapter, error) {
 		errors:           make(map[string]error),
 	}
 
-	for _, opt := range opts {
-		opt(a)
+	if opts != nil {
+		if opts.UseMethodNameSuffix {
+			a.useMethodNameSuffix = true
+		}
 	}
 
 	if err := a.parse(); err != nil {

--- a/entproto/service.go
+++ b/entproto/service.go
@@ -127,6 +127,7 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 	if err != nil {
 		return methodResources{}, err
 	}
+	methodName := a.getMethodName(genType, m)
 	protoMessageFieldType := descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
 	protoEnumFieldType := descriptorpb.FieldDescriptorProto_TYPE_ENUM
 	repeatedFieldLabel := descriptorpb.FieldDescriptorProto_LABEL_REPEATED
@@ -144,12 +145,11 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 		TypeName: strptr(genType.Name),
 	}
 	var (
-		outputName, methodName string
-		messages               []*descriptorpb.DescriptorProto
+		outputName string
+		messages   []*descriptorpb.DescriptorProto
 	)
 	switch m {
 	case MethodGet:
-		methodName = "Get" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Get%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{
 			idField,
@@ -171,19 +171,16 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodCreate:
-		methodName = "Create" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Create%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodUpdate:
-		methodName = "Update" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Update%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodDelete:
-		methodName = "Delete" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Delete%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{idField}
 		outputName = "google.protobuf.Empty"
@@ -194,7 +191,6 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 				genType.Name, genType.ID.Type.String())
 		}
 
-		methodName = "List" + genType.Name
 		int32FieldType := descriptorpb.FieldDescriptorProto_TYPE_INT32
 		stringFieldType := descriptorpb.FieldDescriptorProto_TYPE_STRING
 		input.Name = strptr(fmt.Sprintf("List%sRequest", genType.Name))
@@ -244,7 +240,6 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 		}
 		messages = append(messages, input, output)
 	case MethodBatchCreate:
-		methodName = "BatchCreate" + genType.Name
 		createRequest := &descriptorpb.DescriptorProto{}
 		createRequest.Name = strptr(fmt.Sprintf("Create%sRequest", genType.Name))
 		createRequest.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}

--- a/entproto/service.go
+++ b/entproto/service.go
@@ -149,7 +149,7 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 	)
 	switch m {
 	case MethodGet:
-		methodName = "Get"
+		methodName = "Get" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Get%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{
 			idField,
@@ -171,19 +171,19 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodCreate:
-		methodName = "Create"
+		methodName = "Create" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Create%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodUpdate:
-		methodName = "Update"
+		methodName = "Update" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Update%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}
 		outputName = genType.Name
 		messages = append(messages, input)
 	case MethodDelete:
-		methodName = "Delete"
+		methodName = "Delete" + genType.Name
 		input.Name = strptr(fmt.Sprintf("Delete%sRequest", genType.Name))
 		input.Field = []*descriptorpb.FieldDescriptorProto{idField}
 		outputName = "google.protobuf.Empty"
@@ -194,7 +194,7 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 				genType.Name, genType.ID.Type.String())
 		}
 
-		methodName = "List"
+		methodName = "List" + genType.Name
 		int32FieldType := descriptorpb.FieldDescriptorProto_TYPE_INT32
 		stringFieldType := descriptorpb.FieldDescriptorProto_TYPE_STRING
 		input.Name = strptr(fmt.Sprintf("List%sRequest", genType.Name))
@@ -244,7 +244,7 @@ func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources,
 		}
 		messages = append(messages, input, output)
 	case MethodBatchCreate:
-		methodName = "BatchCreate"
+		methodName = "BatchCreate" + genType.Name
 		createRequest := &descriptorpb.DescriptorProto{}
 		createRequest.Name = strptr(fmt.Sprintf("Create%sRequest", genType.Name))
 		createRequest.Field = []*descriptorpb.FieldDescriptorProto{singleMessageField}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ensigniasec/ent-contrib
+module entgo.io/contrib
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module entgo.io/contrib
+module github.com/ensigniasec/ent-contrib
 
 go 1.18
 


### PR DESCRIPTION
Hi Team,

This PR adds some extra configuration to the generate Hook so that it can output generated code that works with BufBuild's Connect.

Specific changes:

- Make all method names unique so that specific keys don't collide or generate the method `delete()` in JS, and follow the naming conventions specified by the linter.
- Don't create the `generate.go` file since we're using `buf generate` instead of protoc.
- Allow configuring the generation target so we can collocate generated `.proto` with other hand written files outside of `./ent`
- 