### PR TITLE
entgql: Fix duplicate import present in `gql_where_input.go`

### DIFF
--- a/entgql/template/where_input.tmpl
+++ b/entgql/template/where_input.tmpl
@@ -20,7 +20,6 @@ in the LICENSE file in the root directory of this source tree.
 import (
     "{{ $.Config.Package }}/predicate"
 	{{- range $n := $gqlNodes }}
-        {{ template "import/types" $n }}
 		"{{ $.Config.Package }}/{{ $n.Package }}"
 	{{- end }}
 )

--- a/entgql/template/where_input.tmpl
+++ b/entgql/template/where_input.tmpl
@@ -13,16 +13,17 @@ in the LICENSE file in the root directory of this source tree.
         {{ template "header" . }}
 {{- end }}
 
-{{ template "import" $ }}
 
 {{ $gqlNodes := filterNodes $.Nodes (skipMode "where_input") }}
 
 import (
     "{{ $.Config.Package }}/predicate"
 	{{- range $n := $gqlNodes }}
+        {{- template "import/types" $n }}
 		"{{ $.Config.Package }}/{{ $n.Package }}"
 	{{- end }}
 )
+{{ template "import" $ }}
 
 {{ range $n := $gqlNodes }}
     {{ $comparableFields := list $n.ID }}


### PR DESCRIPTION
Fixes https://github.com/ent/ent/issues/3373

* Removes the unnecessary call to template "import/types" since it was just creating an empty line. 