### PR TITLE
entgql: add support for query fields selection

### DIFF
--- a/entgql/internal/todo/ent/gql_collection.go
+++ b/entgql/internal/todo/ent/gql_collection.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todo/ent/billproduct"
 	"entgo.io/contrib/entgql/internal/todo/ent/category"
+	"entgo.io/contrib/entgql/internal/todo/ent/friendship"
 	"entgo.io/contrib/entgql/internal/todo/ent/group"
 	"entgo.io/contrib/entgql/internal/todo/ent/todo"
 	"entgo.io/contrib/entgql/internal/todo/ent/user"
@@ -42,8 +44,37 @@ func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...stri
 	return bp, nil
 }
 
-func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(billproduct.Columns))
+		selectedFields = []string{billproduct.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
+		switch field.Name {
+		case "name":
+			if _, ok := fieldSeen[billproduct.FieldName]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldName)
+				fieldSeen[billproduct.FieldName] = struct{}{}
+			}
+		case "sku":
+			if _, ok := fieldSeen[billproduct.FieldSku]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldSku)
+				fieldSeen[billproduct.FieldSku] = struct{}{}
+			}
+		case "quantity":
+			if _, ok := fieldSeen[billproduct.FieldQuantity]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldQuantity)
+				fieldSeen[billproduct.FieldQuantity] = struct{}{}
+			}
+		default:
+			unknownSeen = true
+		}
+	}
+	if !unknownSeen {
+		bp.Select(selectedFields...)
+	}
 	return nil
 }
 
@@ -88,9 +119,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 	return c, nil
 }
 
-func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(category.Columns))
+		selectedFields = []string{category.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "todos":
 			var (
@@ -266,7 +302,42 @@ func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			c.WithNamedSubCategories(alias, func(wq *CategoryQuery) {
 				*wq = *query
 			})
+		case "text":
+			if _, ok := fieldSeen[category.FieldText]; !ok {
+				selectedFields = append(selectedFields, category.FieldText)
+				fieldSeen[category.FieldText] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[category.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, category.FieldStatus)
+				fieldSeen[category.FieldStatus] = struct{}{}
+			}
+		case "config":
+			if _, ok := fieldSeen[category.FieldConfig]; !ok {
+				selectedFields = append(selectedFields, category.FieldConfig)
+				fieldSeen[category.FieldConfig] = struct{}{}
+			}
+		case "duration":
+			if _, ok := fieldSeen[category.FieldDuration]; !ok {
+				selectedFields = append(selectedFields, category.FieldDuration)
+				fieldSeen[category.FieldDuration] = struct{}{}
+			}
+		case "count":
+			if _, ok := fieldSeen[category.FieldCount]; !ok {
+				selectedFields = append(selectedFields, category.FieldCount)
+				fieldSeen[category.FieldCount] = struct{}{}
+			}
+		case "strings":
+			if _, ok := fieldSeen[category.FieldStrings]; !ok {
+				selectedFields = append(selectedFields, category.FieldStrings)
+				fieldSeen[category.FieldStrings] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		c.Select(selectedFields...)
 	}
 	return nil
 }
@@ -340,9 +411,14 @@ func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string
 	return f, nil
 }
 
-func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(friendship.Columns))
+		selectedFields = []string{friendship.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "user":
 			var (
@@ -364,7 +440,27 @@ func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				return err
 			}
 			f.withFriend = query
+		case "createdAt":
+			if _, ok := fieldSeen[friendship.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldCreatedAt)
+				fieldSeen[friendship.FieldCreatedAt] = struct{}{}
+			}
+		case "userID":
+			if _, ok := fieldSeen[friendship.FieldUserID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldUserID)
+				fieldSeen[friendship.FieldUserID] = struct{}{}
+			}
+		case "friendID":
+			if _, ok := fieldSeen[friendship.FieldFriendID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldFriendID)
+				fieldSeen[friendship.FieldFriendID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		f.Select(selectedFields...)
 	}
 	return nil
 }
@@ -410,9 +506,14 @@ func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*
 	return gr, nil
 }
 
-func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(group.Columns))
+		selectedFields = []string{group.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "users":
 			var (
@@ -503,7 +604,17 @@ func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 			gr.WithNamedUsers(alias, func(wq *UserQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[group.FieldName]; !ok {
+				selectedFields = append(selectedFields, group.FieldName)
+				fieldSeen[group.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		gr.Select(selectedFields...)
 	}
 	return nil
 }
@@ -549,9 +660,14 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*To
 	return t, nil
 }
 
-func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(todo.Columns))
+		selectedFields = []string{todo.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "parent":
 			var (
@@ -658,7 +774,52 @@ func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 				return err
 			}
 			t.withCategory = query
+		case "createdAt":
+			if _, ok := fieldSeen[todo.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCreatedAt)
+				fieldSeen[todo.FieldCreatedAt] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[todo.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, todo.FieldStatus)
+				fieldSeen[todo.FieldStatus] = struct{}{}
+			}
+		case "priorityOrder":
+			if _, ok := fieldSeen[todo.FieldPriority]; !ok {
+				selectedFields = append(selectedFields, todo.FieldPriority)
+				fieldSeen[todo.FieldPriority] = struct{}{}
+			}
+		case "text":
+			if _, ok := fieldSeen[todo.FieldText]; !ok {
+				selectedFields = append(selectedFields, todo.FieldText)
+				fieldSeen[todo.FieldText] = struct{}{}
+			}
+		case "categoryID", "category_id", "categoryX":
+			if _, ok := fieldSeen[todo.FieldCategoryID]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCategoryID)
+				fieldSeen[todo.FieldCategoryID] = struct{}{}
+			}
+		case "init":
+			if _, ok := fieldSeen[todo.FieldInit]; !ok {
+				selectedFields = append(selectedFields, todo.FieldInit)
+				fieldSeen[todo.FieldInit] = struct{}{}
+			}
+		case "custom":
+			if _, ok := fieldSeen[todo.FieldCustom]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustom)
+				fieldSeen[todo.FieldCustom] = struct{}{}
+			}
+		case "customp":
+			if _, ok := fieldSeen[todo.FieldCustomp]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustomp)
+				fieldSeen[todo.FieldCustomp] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		t.Select(selectedFields...)
 	}
 	return nil
 }
@@ -726,9 +887,14 @@ func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*Us
 	return u, nil
 }
 
-func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(user.Columns))
+		selectedFields = []string{user.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "groups":
 			var (
@@ -993,7 +1159,22 @@ func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 			u.WithNamedFriendships(alias, func(wq *FriendshipQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[user.FieldName]; !ok {
+				selectedFields = append(selectedFields, user.FieldName)
+				fieldSeen[user.FieldName] = struct{}{}
+			}
+		case "username":
+			if _, ok := fieldSeen[user.FieldUsername]; !ok {
+				selectedFields = append(selectedFields, user.FieldUsername)
+				fieldSeen[user.FieldUsername] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		u.Select(selectedFields...)
 	}
 	return nil
 }

--- a/entgql/internal/todo/todo_test.go
+++ b/entgql/internal/todo/todo_test.go
@@ -2124,3 +2124,83 @@ func TestMultiFieldsOrder(t *testing.T) {
 		require.False(t, rsp.Categories.PageInfo.HasPreviousPage)
 	})
 }
+
+type queryRecorder struct {
+	queries []string
+	dialect.Driver
+}
+
+func (r *queryRecorder) reset() {
+	r.queries = nil
+}
+
+func (r *queryRecorder) Query(ctx context.Context, query string, args, v interface{}) error {
+	r.queries = append(r.queries, query)
+	return r.Driver.Query(ctx, query, args, v)
+}
+
+func TestFieldSelection(t *testing.T) {
+	ctx := context.Background()
+	drv, err := sql.Open(dialect.SQLite, fmt.Sprintf("file:%s?mode=memory&cache=shared&_fk=1", t.Name()))
+	require.NoError(t, err)
+	rec := &queryRecorder{Driver: drv}
+	ec := enttest.NewClient(t,
+		enttest.WithOptions(ent.Driver(rec)),
+		enttest.WithMigrateOptions(migrate.WithGlobalUniqueID(true)),
+	)
+	root := ec.Todo.CreateBulk(
+		ec.Todo.Create().SetText("t0.1").SetStatus(todo.StatusInProgress),
+		ec.Todo.Create().SetText("t0.2").SetStatus(todo.StatusInProgress),
+		ec.Todo.Create().SetText("t0.3").SetStatus(todo.StatusCompleted),
+	).SaveX(ctx)
+	ec.Todo.CreateBulk(
+		ec.Todo.Create().SetText("t1.1").SetParent(root[0]).SetStatus(todo.StatusInProgress),
+		ec.Todo.Create().SetText("t1.2").SetParent(root[0]).SetStatus(todo.StatusCompleted),
+		ec.Todo.Create().SetText("t1.3").SetParent(root[0]).SetStatus(todo.StatusCompleted),
+	).SaveX(ctx)
+	var (
+		// language=GraphQL
+		query = `query {
+			todos {
+				edges {
+					node {
+						children {
+							totalCount
+							edges {
+								node {
+									text
+								}
+							}
+						}
+					}
+				}
+			}
+		}`
+		rsp struct {
+			Todos struct {
+				Edges []struct {
+					Node struct {
+						Children struct {
+							TotalCount int
+							Edges      []struct {
+								Node struct {
+									Text string
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		gqlc = client.New(handler.NewDefaultServer(gen.NewSchema(ec)))
+	)
+	rec.reset()
+	gqlc.MustPost(query, &rsp)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		// No fields were selected besides the "id" field.
+		"SELECT DISTINCT `todos`.`id` FROM `todos` ORDER BY `todos`.`id` ASC",
+		// The "id" and the "text" fields were selected + all foreign keys (see, `withFKs` query field).
+		"SELECT DISTINCT `todos`.`id`, `todos`.`text`, `todos`.`todo_children`, `todos`.`todo_secret` FROM `todos` WHERE `todo_children` IN (?, ?, ?, ?, ?, ?) ORDER BY `todos`.`id` ASC",
+	}, rec.queries)
+}

--- a/entgql/internal/todofed/ent/gql_collection.go
+++ b/entgql/internal/todofed/ent/gql_collection.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todofed/ent/category"
+	"entgo.io/contrib/entgql/internal/todofed/ent/todo"
 	"entgo.io/ent/dialect/sql"
 	"github.com/99designs/gqlgen/graphql"
 )
@@ -36,9 +38,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 	return c, nil
 }
 
-func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(category.Columns))
+		selectedFields = []string{category.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "todos":
 			var (
@@ -52,7 +59,42 @@ func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			c.WithNamedTodos(alias, func(wq *TodoQuery) {
 				*wq = *query
 			})
+		case "text":
+			if _, ok := fieldSeen[category.FieldText]; !ok {
+				selectedFields = append(selectedFields, category.FieldText)
+				fieldSeen[category.FieldText] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[category.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, category.FieldStatus)
+				fieldSeen[category.FieldStatus] = struct{}{}
+			}
+		case "config":
+			if _, ok := fieldSeen[category.FieldConfig]; !ok {
+				selectedFields = append(selectedFields, category.FieldConfig)
+				fieldSeen[category.FieldConfig] = struct{}{}
+			}
+		case "duration":
+			if _, ok := fieldSeen[category.FieldDuration]; !ok {
+				selectedFields = append(selectedFields, category.FieldDuration)
+				fieldSeen[category.FieldDuration] = struct{}{}
+			}
+		case "count":
+			if _, ok := fieldSeen[category.FieldCount]; !ok {
+				selectedFields = append(selectedFields, category.FieldCount)
+				fieldSeen[category.FieldCount] = struct{}{}
+			}
+		case "strings":
+			if _, ok := fieldSeen[category.FieldStrings]; !ok {
+				selectedFields = append(selectedFields, category.FieldStrings)
+				fieldSeen[category.FieldStrings] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		c.Select(selectedFields...)
 	}
 	return nil
 }
@@ -117,9 +159,14 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*To
 	return t, nil
 }
 
-func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(todo.Columns))
+		selectedFields = []string{todo.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "parent":
 			var (
@@ -153,7 +200,37 @@ func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 				return err
 			}
 			t.withCategory = query
+		case "createdAt":
+			if _, ok := fieldSeen[todo.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCreatedAt)
+				fieldSeen[todo.FieldCreatedAt] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[todo.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, todo.FieldStatus)
+				fieldSeen[todo.FieldStatus] = struct{}{}
+			}
+		case "priority":
+			if _, ok := fieldSeen[todo.FieldPriority]; !ok {
+				selectedFields = append(selectedFields, todo.FieldPriority)
+				fieldSeen[todo.FieldPriority] = struct{}{}
+			}
+		case "text":
+			if _, ok := fieldSeen[todo.FieldText]; !ok {
+				selectedFields = append(selectedFields, todo.FieldText)
+				fieldSeen[todo.FieldText] = struct{}{}
+			}
+		case "blob":
+			if _, ok := fieldSeen[todo.FieldBlob]; !ok {
+				selectedFields = append(selectedFields, todo.FieldBlob)
+				fieldSeen[todo.FieldBlob] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		t.Select(selectedFields...)
 	}
 	return nil
 }

--- a/entgql/internal/todogotype/ent/gql_collection.go
+++ b/entgql/internal/todogotype/ent/gql_collection.go
@@ -22,8 +22,11 @@ import (
 	"fmt"
 
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todogotype/ent/billproduct"
 	"entgo.io/contrib/entgql/internal/todogotype/ent/category"
+	"entgo.io/contrib/entgql/internal/todogotype/ent/friendship"
 	"entgo.io/contrib/entgql/internal/todogotype/ent/group"
+	"entgo.io/contrib/entgql/internal/todogotype/ent/pet"
 	"entgo.io/contrib/entgql/internal/todogotype/ent/schema/bigintgql"
 	"entgo.io/contrib/entgql/internal/todogotype/ent/todo"
 	"entgo.io/contrib/entgql/internal/todogotype/ent/user"
@@ -43,8 +46,37 @@ func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...stri
 	return bp, nil
 }
 
-func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(billproduct.Columns))
+		selectedFields = []string{billproduct.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
+		switch field.Name {
+		case "name":
+			if _, ok := fieldSeen[billproduct.FieldName]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldName)
+				fieldSeen[billproduct.FieldName] = struct{}{}
+			}
+		case "sku":
+			if _, ok := fieldSeen[billproduct.FieldSku]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldSku)
+				fieldSeen[billproduct.FieldSku] = struct{}{}
+			}
+		case "quantity":
+			if _, ok := fieldSeen[billproduct.FieldQuantity]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldQuantity)
+				fieldSeen[billproduct.FieldQuantity] = struct{}{}
+			}
+		default:
+			unknownSeen = true
+		}
+	}
+	if !unknownSeen {
+		bp.Select(selectedFields...)
+	}
 	return nil
 }
 
@@ -89,9 +121,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 	return c, nil
 }
 
-func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(category.Columns))
+		selectedFields = []string{category.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "todos":
 			var (
@@ -267,7 +304,42 @@ func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			c.WithNamedSubCategories(alias, func(wq *CategoryQuery) {
 				*wq = *query
 			})
+		case "text":
+			if _, ok := fieldSeen[category.FieldText]; !ok {
+				selectedFields = append(selectedFields, category.FieldText)
+				fieldSeen[category.FieldText] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[category.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, category.FieldStatus)
+				fieldSeen[category.FieldStatus] = struct{}{}
+			}
+		case "config":
+			if _, ok := fieldSeen[category.FieldConfig]; !ok {
+				selectedFields = append(selectedFields, category.FieldConfig)
+				fieldSeen[category.FieldConfig] = struct{}{}
+			}
+		case "duration":
+			if _, ok := fieldSeen[category.FieldDuration]; !ok {
+				selectedFields = append(selectedFields, category.FieldDuration)
+				fieldSeen[category.FieldDuration] = struct{}{}
+			}
+		case "count":
+			if _, ok := fieldSeen[category.FieldCount]; !ok {
+				selectedFields = append(selectedFields, category.FieldCount)
+				fieldSeen[category.FieldCount] = struct{}{}
+			}
+		case "strings":
+			if _, ok := fieldSeen[category.FieldStrings]; !ok {
+				selectedFields = append(selectedFields, category.FieldStrings)
+				fieldSeen[category.FieldStrings] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		c.Select(selectedFields...)
 	}
 	return nil
 }
@@ -341,9 +413,14 @@ func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string
 	return f, nil
 }
 
-func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(friendship.Columns))
+		selectedFields = []string{friendship.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "user":
 			var (
@@ -365,7 +442,27 @@ func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				return err
 			}
 			f.withFriend = query
+		case "createdAt":
+			if _, ok := fieldSeen[friendship.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldCreatedAt)
+				fieldSeen[friendship.FieldCreatedAt] = struct{}{}
+			}
+		case "userID":
+			if _, ok := fieldSeen[friendship.FieldUserID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldUserID)
+				fieldSeen[friendship.FieldUserID] = struct{}{}
+			}
+		case "friendID":
+			if _, ok := fieldSeen[friendship.FieldFriendID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldFriendID)
+				fieldSeen[friendship.FieldFriendID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		f.Select(selectedFields...)
 	}
 	return nil
 }
@@ -411,9 +508,14 @@ func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*
 	return gr, nil
 }
 
-func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(group.Columns))
+		selectedFields = []string{group.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "users":
 			var (
@@ -504,7 +606,17 @@ func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 			gr.WithNamedUsers(alias, func(wq *UserQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[group.FieldName]; !ok {
+				selectedFields = append(selectedFields, group.FieldName)
+				fieldSeen[group.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		gr.Select(selectedFields...)
 	}
 	return nil
 }
@@ -550,8 +662,27 @@ func (pe *PetQuery) CollectFields(ctx context.Context, satisfies ...string) (*Pe
 	return pe, nil
 }
 
-func (pe *PetQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (pe *PetQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(pet.Columns))
+		selectedFields = []string{pet.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
+		switch field.Name {
+		case "name":
+			if _, ok := fieldSeen[pet.FieldName]; !ok {
+				selectedFields = append(selectedFields, pet.FieldName)
+				fieldSeen[pet.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
+		}
+	}
+	if !unknownSeen {
+		pe.Select(selectedFields...)
+	}
 	return nil
 }
 
@@ -596,9 +727,14 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*To
 	return t, nil
 }
 
-func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(todo.Columns))
+		selectedFields = []string{todo.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "parent":
 			var (
@@ -705,7 +841,52 @@ func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 				return err
 			}
 			t.withCategory = query
+		case "createdAt":
+			if _, ok := fieldSeen[todo.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCreatedAt)
+				fieldSeen[todo.FieldCreatedAt] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[todo.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, todo.FieldStatus)
+				fieldSeen[todo.FieldStatus] = struct{}{}
+			}
+		case "priorityOrder":
+			if _, ok := fieldSeen[todo.FieldPriority]; !ok {
+				selectedFields = append(selectedFields, todo.FieldPriority)
+				fieldSeen[todo.FieldPriority] = struct{}{}
+			}
+		case "text":
+			if _, ok := fieldSeen[todo.FieldText]; !ok {
+				selectedFields = append(selectedFields, todo.FieldText)
+				fieldSeen[todo.FieldText] = struct{}{}
+			}
+		case "init":
+			if _, ok := fieldSeen[todo.FieldInit]; !ok {
+				selectedFields = append(selectedFields, todo.FieldInit)
+				fieldSeen[todo.FieldInit] = struct{}{}
+			}
+		case "custom":
+			if _, ok := fieldSeen[todo.FieldCustom]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustom)
+				fieldSeen[todo.FieldCustom] = struct{}{}
+			}
+		case "customp":
+			if _, ok := fieldSeen[todo.FieldCustomp]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustomp)
+				fieldSeen[todo.FieldCustomp] = struct{}{}
+			}
+		case "categoryID":
+			if _, ok := fieldSeen[todo.FieldCategoryID]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCategoryID)
+				fieldSeen[todo.FieldCategoryID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		t.Select(selectedFields...)
 	}
 	return nil
 }
@@ -773,9 +954,14 @@ func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*Us
 	return u, nil
 }
 
-func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(user.Columns))
+		selectedFields = []string{user.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "groups":
 			var (
@@ -890,7 +1076,17 @@ func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 			u.WithNamedFriendships(alias, func(wq *FriendshipQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[user.FieldName]; !ok {
+				selectedFields = append(selectedFields, user.FieldName)
+				fieldSeen[user.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		u.Select(selectedFields...)
 	}
 	return nil
 }

--- a/entgql/internal/todopulid/ent/gql_collection.go
+++ b/entgql/internal/todopulid/ent/gql_collection.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todopulid/ent/billproduct"
 	"entgo.io/contrib/entgql/internal/todopulid/ent/category"
+	"entgo.io/contrib/entgql/internal/todopulid/ent/friendship"
 	"entgo.io/contrib/entgql/internal/todopulid/ent/group"
 	"entgo.io/contrib/entgql/internal/todopulid/ent/schema/pulid"
 	"entgo.io/contrib/entgql/internal/todopulid/ent/todo"
@@ -43,8 +45,37 @@ func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...stri
 	return bp, nil
 }
 
-func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(billproduct.Columns))
+		selectedFields = []string{billproduct.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
+		switch field.Name {
+		case "name":
+			if _, ok := fieldSeen[billproduct.FieldName]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldName)
+				fieldSeen[billproduct.FieldName] = struct{}{}
+			}
+		case "sku":
+			if _, ok := fieldSeen[billproduct.FieldSku]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldSku)
+				fieldSeen[billproduct.FieldSku] = struct{}{}
+			}
+		case "quantity":
+			if _, ok := fieldSeen[billproduct.FieldQuantity]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldQuantity)
+				fieldSeen[billproduct.FieldQuantity] = struct{}{}
+			}
+		default:
+			unknownSeen = true
+		}
+	}
+	if !unknownSeen {
+		bp.Select(selectedFields...)
+	}
 	return nil
 }
 
@@ -89,9 +120,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 	return c, nil
 }
 
-func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(category.Columns))
+		selectedFields = []string{category.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "todos":
 			var (
@@ -267,7 +303,42 @@ func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			c.WithNamedSubCategories(alias, func(wq *CategoryQuery) {
 				*wq = *query
 			})
+		case "text":
+			if _, ok := fieldSeen[category.FieldText]; !ok {
+				selectedFields = append(selectedFields, category.FieldText)
+				fieldSeen[category.FieldText] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[category.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, category.FieldStatus)
+				fieldSeen[category.FieldStatus] = struct{}{}
+			}
+		case "config":
+			if _, ok := fieldSeen[category.FieldConfig]; !ok {
+				selectedFields = append(selectedFields, category.FieldConfig)
+				fieldSeen[category.FieldConfig] = struct{}{}
+			}
+		case "duration":
+			if _, ok := fieldSeen[category.FieldDuration]; !ok {
+				selectedFields = append(selectedFields, category.FieldDuration)
+				fieldSeen[category.FieldDuration] = struct{}{}
+			}
+		case "count":
+			if _, ok := fieldSeen[category.FieldCount]; !ok {
+				selectedFields = append(selectedFields, category.FieldCount)
+				fieldSeen[category.FieldCount] = struct{}{}
+			}
+		case "strings":
+			if _, ok := fieldSeen[category.FieldStrings]; !ok {
+				selectedFields = append(selectedFields, category.FieldStrings)
+				fieldSeen[category.FieldStrings] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		c.Select(selectedFields...)
 	}
 	return nil
 }
@@ -341,9 +412,14 @@ func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string
 	return f, nil
 }
 
-func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(friendship.Columns))
+		selectedFields = []string{friendship.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "user":
 			var (
@@ -365,7 +441,27 @@ func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				return err
 			}
 			f.withFriend = query
+		case "createdAt":
+			if _, ok := fieldSeen[friendship.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldCreatedAt)
+				fieldSeen[friendship.FieldCreatedAt] = struct{}{}
+			}
+		case "userID":
+			if _, ok := fieldSeen[friendship.FieldUserID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldUserID)
+				fieldSeen[friendship.FieldUserID] = struct{}{}
+			}
+		case "friendID":
+			if _, ok := fieldSeen[friendship.FieldFriendID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldFriendID)
+				fieldSeen[friendship.FieldFriendID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		f.Select(selectedFields...)
 	}
 	return nil
 }
@@ -411,9 +507,14 @@ func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*
 	return gr, nil
 }
 
-func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(group.Columns))
+		selectedFields = []string{group.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "users":
 			var (
@@ -504,7 +605,17 @@ func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 			gr.WithNamedUsers(alias, func(wq *UserQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[group.FieldName]; !ok {
+				selectedFields = append(selectedFields, group.FieldName)
+				fieldSeen[group.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		gr.Select(selectedFields...)
 	}
 	return nil
 }
@@ -550,9 +661,14 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*To
 	return t, nil
 }
 
-func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(todo.Columns))
+		selectedFields = []string{todo.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "parent":
 			var (
@@ -659,7 +775,52 @@ func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 				return err
 			}
 			t.withCategory = query
+		case "createdAt":
+			if _, ok := fieldSeen[todo.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCreatedAt)
+				fieldSeen[todo.FieldCreatedAt] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[todo.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, todo.FieldStatus)
+				fieldSeen[todo.FieldStatus] = struct{}{}
+			}
+		case "priorityOrder":
+			if _, ok := fieldSeen[todo.FieldPriority]; !ok {
+				selectedFields = append(selectedFields, todo.FieldPriority)
+				fieldSeen[todo.FieldPriority] = struct{}{}
+			}
+		case "text":
+			if _, ok := fieldSeen[todo.FieldText]; !ok {
+				selectedFields = append(selectedFields, todo.FieldText)
+				fieldSeen[todo.FieldText] = struct{}{}
+			}
+		case "init":
+			if _, ok := fieldSeen[todo.FieldInit]; !ok {
+				selectedFields = append(selectedFields, todo.FieldInit)
+				fieldSeen[todo.FieldInit] = struct{}{}
+			}
+		case "custom":
+			if _, ok := fieldSeen[todo.FieldCustom]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustom)
+				fieldSeen[todo.FieldCustom] = struct{}{}
+			}
+		case "customp":
+			if _, ok := fieldSeen[todo.FieldCustomp]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustomp)
+				fieldSeen[todo.FieldCustomp] = struct{}{}
+			}
+		case "categoryID":
+			if _, ok := fieldSeen[todo.FieldCategoryID]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCategoryID)
+				fieldSeen[todo.FieldCategoryID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		t.Select(selectedFields...)
 	}
 	return nil
 }
@@ -727,9 +888,14 @@ func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*Us
 	return u, nil
 }
 
-func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(user.Columns))
+		selectedFields = []string{user.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "groups":
 			var (
@@ -844,7 +1010,22 @@ func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 			u.WithNamedFriendships(alias, func(wq *FriendshipQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[user.FieldName]; !ok {
+				selectedFields = append(selectedFields, user.FieldName)
+				fieldSeen[user.FieldName] = struct{}{}
+			}
+		case "username":
+			if _, ok := fieldSeen[user.FieldUsername]; !ok {
+				selectedFields = append(selectedFields, user.FieldUsername)
+				fieldSeen[user.FieldUsername] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		u.Select(selectedFields...)
 	}
 	return nil
 }

--- a/entgql/internal/todouuid/ent/gql_collection.go
+++ b/entgql/internal/todouuid/ent/gql_collection.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	"entgo.io/contrib/entgql"
+	"entgo.io/contrib/entgql/internal/todouuid/ent/billproduct"
 	"entgo.io/contrib/entgql/internal/todouuid/ent/category"
+	"entgo.io/contrib/entgql/internal/todouuid/ent/friendship"
 	"entgo.io/contrib/entgql/internal/todouuid/ent/group"
 	"entgo.io/contrib/entgql/internal/todouuid/ent/todo"
 	"entgo.io/contrib/entgql/internal/todouuid/ent/user"
@@ -43,8 +45,37 @@ func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...stri
 	return bp, nil
 }
 
-func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (bp *BillProductQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(billproduct.Columns))
+		selectedFields = []string{billproduct.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
+		switch field.Name {
+		case "name":
+			if _, ok := fieldSeen[billproduct.FieldName]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldName)
+				fieldSeen[billproduct.FieldName] = struct{}{}
+			}
+		case "sku":
+			if _, ok := fieldSeen[billproduct.FieldSku]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldSku)
+				fieldSeen[billproduct.FieldSku] = struct{}{}
+			}
+		case "quantity":
+			if _, ok := fieldSeen[billproduct.FieldQuantity]; !ok {
+				selectedFields = append(selectedFields, billproduct.FieldQuantity)
+				fieldSeen[billproduct.FieldQuantity] = struct{}{}
+			}
+		default:
+			unknownSeen = true
+		}
+	}
+	if !unknownSeen {
+		bp.Select(selectedFields...)
+	}
 	return nil
 }
 
@@ -89,9 +120,14 @@ func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) 
 	return c, nil
 }
 
-func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(category.Columns))
+		selectedFields = []string{category.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "todos":
 			var (
@@ -267,7 +303,42 @@ func (c *CategoryQuery) collectField(ctx context.Context, opCtx *graphql.Operati
 			c.WithNamedSubCategories(alias, func(wq *CategoryQuery) {
 				*wq = *query
 			})
+		case "text":
+			if _, ok := fieldSeen[category.FieldText]; !ok {
+				selectedFields = append(selectedFields, category.FieldText)
+				fieldSeen[category.FieldText] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[category.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, category.FieldStatus)
+				fieldSeen[category.FieldStatus] = struct{}{}
+			}
+		case "config":
+			if _, ok := fieldSeen[category.FieldConfig]; !ok {
+				selectedFields = append(selectedFields, category.FieldConfig)
+				fieldSeen[category.FieldConfig] = struct{}{}
+			}
+		case "duration":
+			if _, ok := fieldSeen[category.FieldDuration]; !ok {
+				selectedFields = append(selectedFields, category.FieldDuration)
+				fieldSeen[category.FieldDuration] = struct{}{}
+			}
+		case "count":
+			if _, ok := fieldSeen[category.FieldCount]; !ok {
+				selectedFields = append(selectedFields, category.FieldCount)
+				fieldSeen[category.FieldCount] = struct{}{}
+			}
+		case "strings":
+			if _, ok := fieldSeen[category.FieldStrings]; !ok {
+				selectedFields = append(selectedFields, category.FieldStrings)
+				fieldSeen[category.FieldStrings] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		c.Select(selectedFields...)
 	}
 	return nil
 }
@@ -341,9 +412,14 @@ func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string
 	return f, nil
 }
 
-func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(friendship.Columns))
+		selectedFields = []string{friendship.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "user":
 			var (
@@ -365,7 +441,27 @@ func (f *FriendshipQuery) collectField(ctx context.Context, opCtx *graphql.Opera
 				return err
 			}
 			f.withFriend = query
+		case "createdAt":
+			if _, ok := fieldSeen[friendship.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldCreatedAt)
+				fieldSeen[friendship.FieldCreatedAt] = struct{}{}
+			}
+		case "userID":
+			if _, ok := fieldSeen[friendship.FieldUserID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldUserID)
+				fieldSeen[friendship.FieldUserID] = struct{}{}
+			}
+		case "friendID":
+			if _, ok := fieldSeen[friendship.FieldFriendID]; !ok {
+				selectedFields = append(selectedFields, friendship.FieldFriendID)
+				fieldSeen[friendship.FieldFriendID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		f.Select(selectedFields...)
 	}
 	return nil
 }
@@ -411,9 +507,14 @@ func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*
 	return gr, nil
 }
 
-func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(group.Columns))
+		selectedFields = []string{group.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "users":
 			var (
@@ -504,7 +605,17 @@ func (gr *GroupQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 			gr.WithNamedUsers(alias, func(wq *UserQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[group.FieldName]; !ok {
+				selectedFields = append(selectedFields, group.FieldName)
+				fieldSeen[group.FieldName] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		gr.Select(selectedFields...)
 	}
 	return nil
 }
@@ -550,9 +661,14 @@ func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*To
 	return t, nil
 }
 
-func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(todo.Columns))
+		selectedFields = []string{todo.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "parent":
 			var (
@@ -659,7 +775,52 @@ func (t *TodoQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 				return err
 			}
 			t.withCategory = query
+		case "createdAt":
+			if _, ok := fieldSeen[todo.FieldCreatedAt]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCreatedAt)
+				fieldSeen[todo.FieldCreatedAt] = struct{}{}
+			}
+		case "status":
+			if _, ok := fieldSeen[todo.FieldStatus]; !ok {
+				selectedFields = append(selectedFields, todo.FieldStatus)
+				fieldSeen[todo.FieldStatus] = struct{}{}
+			}
+		case "priorityOrder":
+			if _, ok := fieldSeen[todo.FieldPriority]; !ok {
+				selectedFields = append(selectedFields, todo.FieldPriority)
+				fieldSeen[todo.FieldPriority] = struct{}{}
+			}
+		case "text":
+			if _, ok := fieldSeen[todo.FieldText]; !ok {
+				selectedFields = append(selectedFields, todo.FieldText)
+				fieldSeen[todo.FieldText] = struct{}{}
+			}
+		case "init":
+			if _, ok := fieldSeen[todo.FieldInit]; !ok {
+				selectedFields = append(selectedFields, todo.FieldInit)
+				fieldSeen[todo.FieldInit] = struct{}{}
+			}
+		case "custom":
+			if _, ok := fieldSeen[todo.FieldCustom]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustom)
+				fieldSeen[todo.FieldCustom] = struct{}{}
+			}
+		case "customp":
+			if _, ok := fieldSeen[todo.FieldCustomp]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCustomp)
+				fieldSeen[todo.FieldCustomp] = struct{}{}
+			}
+		case "categoryID":
+			if _, ok := fieldSeen[todo.FieldCategoryID]; !ok {
+				selectedFields = append(selectedFields, todo.FieldCategoryID)
+				fieldSeen[todo.FieldCategoryID] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		t.Select(selectedFields...)
 	}
 	return nil
 }
@@ -727,9 +888,14 @@ func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*Us
 	return u, nil
 }
 
-func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	var (
+		unknownSeen    bool
+		fieldSeen      = make(map[string]struct{}, len(user.Columns))
+		selectedFields = []string{user.FieldID}
+	)
+	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 		case "groups":
 			var (
@@ -844,7 +1010,22 @@ func (u *UserQuery) collectField(ctx context.Context, opCtx *graphql.OperationCo
 			u.WithNamedFriendships(alias, func(wq *FriendshipQuery) {
 				*wq = *query
 			})
+		case "name":
+			if _, ok := fieldSeen[user.FieldName]; !ok {
+				selectedFields = append(selectedFields, user.FieldName)
+				fieldSeen[user.FieldName] = struct{}{}
+			}
+		case "username":
+			if _, ok := fieldSeen[user.FieldUsername]; !ok {
+				selectedFields = append(selectedFields, user.FieldUsername)
+				fieldSeen[user.FieldUsername] = struct{}{}
+			}
+		default:
+			unknownSeen = true
 		}
+	}
+	if !unknownSeen {
+		u.Select(selectedFields...)
 	}
 	return nil
 }

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -641,18 +641,17 @@ func (e *schemaGenerator) fieldDefinitions(gqlType string, f *gen.Field, ant *An
 	if err != nil {
 		return nil, fmt.Errorf("field(%s): %w", f.Name, err)
 	}
-
 	var (
-		fields      = []*ast.FieldDefinition{}
-		mappings    = []string{camel(f.Name)}
+		fields      []*ast.FieldDefinition
 		goFieldName = templates.ToGo(f.Name)
 		structField = f.StructField()
 	)
-	if len(ant.Mapping) > 0 {
-		mappings = ant.Mapping
+	mapping, err := fieldMapping(f)
+	if err != nil {
+		return nil, err
 	}
-	for _, name := range mappings {
-		field := &ast.FieldDefinition{
+	for _, name := range mapping {
+		def := &ast.FieldDefinition{
 			Name:        name,
 			Type:        ft,
 			Description: f.Comment(),
@@ -661,11 +660,23 @@ func (e *schemaGenerator) fieldDefinitions(gqlType string, f *gen.Field, ant *An
 		// We check the field name with gqlgen's naming convention.
 		// To avoid unnecessary @goField directives
 		if goFieldName != templates.ToGo(name) {
-			field.Directives = append(field.Directives, goField(structField))
+			def.Directives = append(def.Directives, goField(structField))
 		}
-		fields = append(fields, field)
+		fields = append(fields, def)
 	}
 	return fields, nil
+}
+
+// fieldMapping returns the GraphQL names mapping of a field.
+func fieldMapping(f *gen.Field) ([]string, error) {
+	ant, err := annotation(f.Annotations)
+	if err != nil || ant.Skip.Is(SkipType) || f.Sensitive() {
+		return nil, err
+	}
+	if len(ant.Mapping) > 0 {
+		return ant.Mapping, nil
+	}
+	return []string{camel(f.Name)}, nil
 }
 
 func (e *schemaGenerator) fieldDefinitionOp(gqlType string, f *gen.Field, ant *Annotation, op gen.Op) *ast.FieldDefinition {

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -76,6 +76,7 @@ var (
 	// TemplateFuncs contains the extra template functions used by entgql.
 	TemplateFuncs = template.FuncMap{
 		"fieldCollections":    fieldCollections,
+		"fieldMapping":        fieldMapping,
 		"filterEdges":         filterEdges,
 		"filterFields":        filterFields,
 		"filterNodes":         filterNodes,

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -38,10 +38,22 @@ func ({{ $receiver }} *{{ $query }}) CollectFields(ctx context.Context, satisfie
 	return {{ $receiver }}, nil
 }
 
-func ({{ $receiver }} *{{ $query }}) collectField(ctx context.Context, opCtx *graphql.OperationContext, field graphql.CollectedField, path []string, satisfies ...string) error {
+func ({{ $receiver }} *{{ $query }}) collectField(ctx context.Context, opCtx *graphql.OperationContext, collected graphql.CollectedField, path []string, satisfies ...string) error {
 	path = append([]string(nil), path...)
-	{{- if $collects := fieldCollections (filterEdges $node.Edges (skipMode "type")) }}
-		for _, field := range graphql.CollectFields(opCtx, field.Selections, satisfies) {
+	{{- $fields := filterFields $node.Fields (skipMode "type") }}
+	{{- $collects := fieldCollections (filterEdges $node.Edges (skipMode "type")) }}
+	{{- if or $collects $fields }}
+		var (
+			unknownSeen bool
+			fieldSeen = make(map[string]struct{}, len({{ $node.Package }}.Columns))
+			selectedFields =
+			{{- if $node.HasOneFieldID -}}
+				[]string{ {{ $node.Package }}.{{ $node.ID.Constant }} }
+			{{- else -}}
+				make([]string, 0, len({{ $node.Package }}.Columns))
+			{{- end }}
+		)
+		for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 			switch field.Name {
 				{{- range $i, $fc := $collects }}
 					{{- $e := $fc.Edge }}
@@ -127,8 +139,25 @@ func ({{ $receiver }} *{{ $query }}) collectField(ctx context.Context, opCtx *gr
 							})
 						{{- end }}
 				{{- end }}
+				{{- range $f := $fields }}
+					{{- with fieldMapping $f }}
+						case {{ range $i, $m := . }}{{ if $i }},{{ end }}"{{ . }}"{{ end }}:
+							if _, ok := fieldSeen[{{ $node.Package }}.{{ $f.Constant }}]; !ok {
+								selectedFields = append(selectedFields, {{ $node.Package }}.{{ $f.Constant }})
+								fieldSeen[{{ $node.Package }}.{{ $f.Constant }}] = struct{}{}
+							}
+					{{- end }}
+				{{- end }}
+				default:
+					unknownSeen = true
 			}
 		}
+		{{- if $fields }}
+			{{- /* In case the schema was extended, a non-selected field might be used by a custom resolver. */}}
+			if !unknownSeen {
+				{{ $receiver }}.Select(selectedFields...)
+			}
+		{{- end }}
 	{{- end }}
 	return nil
 }


### PR DESCRIPTION
Note that if the schema was extended, an unrecognized field was queried, entgql skips the fields selection because we cannot determine if a non-selected field is used in custom resolvers.

Wait with the review until I add tests to this PR. 