### PR TITLE
fix(entgql): pagination variable name getting incorrectly shadowed in template

### DIFF
--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -272,8 +272,8 @@ func (p *{{ $pager }}) applyFilter(query *{{ $query }}) (*{{ $query }}, error) {
 func (p *{{ $pager }}) toCursor({{ $r }} *{{ $name }}) Cursor {
 	{{- if $multiOrder }}
 		cs := make([]any, 0, len(p.order))
-		for _, o := range p.order {
-			cs = append(cs, o.Field.toCursor({{ $r }}).Value)
+		for _, _o := range p.order {
+			cs = append(cs, _o.Field.toCursor({{ $r }}).Value)
 		}
 		{{- $marshalID := and $idType.Mixed (gqlMarshaler $node.ID) }}
 		return Cursor{ID: {{ $r }}.{{ if $marshalID }}marshalID(){{ else }}ID{{ end }}, Value: cs}


### PR DESCRIPTION
```go
func (p *organizationPager) toCursor(o *Organization) Cursor {
	cs := make([]any, 0, len(p.order))
	for _, o := range p.order {
		cs = append(cs, o.Field.toCursor(o).Value)
	}
	return Cursor{ID: o.ID, Value: cs}
}
```

if you look at the example above, the `o *Organization` is getting shadowed by the inner loop variable => type mismatches.
added a `_` prefix to the inner loop `o` to avoid these sorts of conflicts