### PR TITLE
fix: ensure graph target has a path

### DIFF
--- a/entproto/extension.go
+++ b/entproto/extension.go
@@ -110,6 +110,15 @@ func Generate(g *gen.Graph) error {
 }
 
 func (e *Extension) generate(g *gen.Graph) error {
+	if g.Config.Target == "" {
+		abs, err := filepath.Abs("./")
+		if err != nil {
+			return fmt.Errorf("entproto: failed getting an absolute path from the graph target: %w", err)
+		}
+
+		g.Config.Target = abs
+	}
+
 	entProtoDir := path.Join(g.Config.Target, "proto")
 	if e.protoDir != "" {
 		entProtoDir = e.protoDir


### PR DESCRIPTION
`g.Config.Target` always seems to be an empty string.

Fixes https://github.com/ent/ent/issues/3467