### PR TITLE
entgql: don't query data if totalCount is zero

### DIFF
--- a/entgql/internal/todo/ent/gql_pagination.go
+++ b/entgql/internal/todo/ent/gql_pagination.go
@@ -298,6 +298,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = bp.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -592,6 +595,9 @@ func (c *CategoryQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = c.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -963,6 +969,9 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = f.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1245,6 +1254,9 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = gr.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1490,6 +1502,9 @@ func (otm *OneToManyQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = otm.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -1784,6 +1799,9 @@ func (pr *ProjectQuery) Paginate(
 			if conn.TotalCount, err = pr.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -2038,6 +2056,9 @@ func (t *TodoQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = t.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -2466,6 +2487,9 @@ func (u *UserQuery) Paginate(
 			if conn.TotalCount, err = u.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -2766,6 +2790,9 @@ func (w *WorkspaceQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = w.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0

--- a/entgql/internal/todofed/ent/gql_pagination.go
+++ b/entgql/internal/todofed/ent/gql_pagination.go
@@ -291,6 +291,9 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -601,6 +604,9 @@ func (t *TodoQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = t.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0

--- a/entgql/internal/todogotype/ent/gql_pagination.go
+++ b/entgql/internal/todogotype/ent/gql_pagination.go
@@ -296,6 +296,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = bp.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -590,6 +593,9 @@ func (c *CategoryQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = c.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -943,6 +949,9 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = f.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1189,6 +1198,9 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = gr.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1434,6 +1446,9 @@ func (pe *PetQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = pe.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -1689,6 +1704,9 @@ func (t *TodoQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = t.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -2116,6 +2134,9 @@ func (u *UserQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = u.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0

--- a/entgql/internal/todopulid/ent/gql_pagination.go
+++ b/entgql/internal/todopulid/ent/gql_pagination.go
@@ -296,6 +296,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = bp.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -590,6 +593,9 @@ func (c *CategoryQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = c.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -943,6 +949,9 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = f.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1225,6 +1234,9 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = gr.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1479,6 +1491,9 @@ func (t *TodoQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = t.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -1906,6 +1921,9 @@ func (u *UserQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = u.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0

--- a/entgql/internal/todouuid/ent/gql_pagination.go
+++ b/entgql/internal/todouuid/ent/gql_pagination.go
@@ -296,6 +296,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = bp.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -590,6 +593,9 @@ func (c *CategoryQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = c.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -943,6 +949,9 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = f.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1225,6 +1234,9 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = gr.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
@@ -1479,6 +1491,9 @@ func (t *TodoQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = t.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
@@ -1906,6 +1921,9 @@ func (u *UserQuery) Paginate(
 		if hasPagination || ignoredEdges {
 			if conn.TotalCount, err = u.Clone().Count(ctx); err != nil {
 				return nil, err
+			}
+			if conn.TotalCount == 0 {
+				return conn, nil
 			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -634,6 +634,9 @@ func ({{ $r }} *{{ $name }}) ToEdge(order *{{ $order }}) *{{ $edge }} {
 			if conn.TotalCount, err = {{ $r }}.Clone().Count(ctx); err != nil {
 				return nil, err
 			}
+			if conn.TotalCount == 0 {
+				return conn, nil
+			}
 			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
 			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}


### PR DESCRIPTION
Thank you for the phenomenal project! I really like ent and thrilled for my 1st PR here 😃 
 
This is an optimization for `Paginate()` method. 

Problem:
`Paginate()` method sends 2 queries when client asks for `totalCount` / `pageInfo` fields: 

1. For `totalCount`.
2. For the paginated data itself.

If pagination has "heavy" filters that are time consuming we'll still wait for 2nd query although we already know there won't be any data there.  

Fix:
We can have a guard clause for zero entities case and spare the 2nd query to the db. 