### PR TITLE
 fix tmpl package alias

### DIFF
--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -16,7 +16,7 @@ in the LICENSE file in the root directory of this source tree.
 import (
 	"github.com/99designs/gqlgen/graphql"
 	{{- range $n := $gqlNodes }}
-		"{{ $.Config.Package }}/{{ $n.Package }}"
+		{{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
 	{{- end }}
 )
 

--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -13,7 +13,7 @@
 import (
     {{- range $n := $gqlNodes }}
         {{- template "import/types" $n }}
-        "{{ $.Config.Package }}/{{ $n.Package }}"
+        {{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
     {{- end }}
 )
 

--- a/entgql/template/node.tmpl
+++ b/entgql/template/node.tmpl
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 
 	{{- range $n := $.Nodes }}
-		"{{ $.Config.Package }}/{{ $n.Package }}"
+		{{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
 	{{- end }}
 	{{- with $package := $idType.PkgPath }}
 		"{{ $package }}"

--- a/entgql/template/node_descriptor.tmpl
+++ b/entgql/template/node_descriptor.tmpl
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 
 	{{- range $n := $.Nodes }}
-		"{{ $.Config.Package }}/{{ $n.Package }}"
+		{{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
 	{{- end }}
 	{{- with $package := $idType.PkgPath }}
 		"{{ $package }}"

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -28,7 +28,7 @@ import (
 	"encoding/base64"
 
 	{{- range $n := $gqlNodes }}
-		"{{ $.Config.Package }}/{{ $n.Package }}"
+		{{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
 	{{- end }}
 
 	"entgo.io/ent/dialect/sql"

--- a/entgql/template/where_input.tmpl
+++ b/entgql/template/where_input.tmpl
@@ -20,7 +20,7 @@ import (
     "{{ $.Config.Package }}/predicate"
 	{{- range $n := $gqlNodes }}
         {{- template "import/types" $n }}
-		"{{ $.Config.Package }}/{{ $n.Package }}"
+        {{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
 	{{- end }}
 )
 {{ template "import" $ }}


### PR DESCRIPTION
use some  package import code as ent latest commit.

[ent tmpl](https://github.com/ent/ent/blob/c46cf6317b25707f86bd568acbaefd083c2c175f/entc/gen/template/client.tmpl#L61)

```
line61   {{ $n.PackageAlias }} "{{ $n.Config.Package }}/{{ $n.PackageDir }}"
```
and Graph.Type
```
// Package returns the package name of this node.
func (t Type) Package() string {
	if name := t.PackageAlias(); name != "" {
		return name
	}
	return t.PackageDir()
}
```

the package name use alias first.

This PR avoid Schema Node use alias name but gql code use Schema name
