### PR TITLE
Entoas: check EdgeOperations when forming a request body

### DIFF
--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -705,6 +705,13 @@ func reqBody(n *gen.Type, op Operation) (*ogen.RequestBody, error) {
 		}
 	}
 	for _, e := range n.Edges {
+		a, err := EdgeOperations(e)
+		if err != nil {
+			return nil, err
+		}
+		if !contains(a, op) {
+			continue
+		}
 		s, err := OgenSchema(e.Type.ID)
 		if err != nil {
 			return nil, err

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -643,9 +643,9 @@ func EdgeOperations(e *gen.Edge) ([]Operation, error) {
 	if e.Annotations == nil || e.Annotations[ant.Name()] == nil {
 		if c.DefaultPolicy == PolicyExpose {
 			if e.Unique {
-				return []Operation{OpRead}, nil
+				return []Operation{OpRead, OpCreate, OpDelete, OpUpdate}, nil
 			} else {
-				return []Operation{OpList}, nil
+				return []Operation{OpList, OpCreate, OpDelete, OpUpdate}, nil
 			}
 		}
 		return nil, nil
@@ -658,6 +658,9 @@ func EdgeOperations(e *gen.Edge) ([]Operation, error) {
 		}
 		var ops []Operation
 		m := make(map[Operation]OperationConfig)
+		m[OpCreate] = ant.Create
+		m[OpDelete] = ant.Delete
+		m[OpUpdate] = ant.Update
 		if e.Unique {
 			m[OpRead] = ant.Read
 		} else {

--- a/entoas/internal/pets/openapi.json
+++ b/entoas/internal/pets/openapi.json
@@ -1202,55 +1202,7 @@
           "name"
         ]
       },
-      "Category_PetsCreate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nicknames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
       "Category_PetsList": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nicknames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
-      "Category_PetsUpdate": {
         "type": "object",
         "properties": {
           "id": {
@@ -1427,21 +1379,6 @@
           "name"
         ]
       },
-      "Pet_CategoriesCreate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
       "Pet_CategoriesList": {
         "type": "object",
         "properties": {
@@ -1450,45 +1387,6 @@
           },
           "name": {
             "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
-      "Pet_CategoriesUpdate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
-      "Pet_FriendsCreate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nicknames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer"
           }
         },
         "required": [
@@ -1520,45 +1418,7 @@
           "name"
         ]
       },
-      "Pet_OwnerCreate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "age"
-        ]
-      },
       "Pet_OwnerRead": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "age"
-        ]
-      },
-      "Pet_OwnerUpdate": {
         "type": "object",
         "properties": {
           "id": {
@@ -1678,55 +1538,7 @@
           "age"
         ]
       },
-      "User_PetsCreate": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nicknames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
       "User_PetsList": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "nicknames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "age": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "name"
-        ]
-      },
-      "User_PetsUpdate": {
         "type": "object",
         "properties": {
           "id": {

--- a/entoas/internal/pets/openapi.json
+++ b/entoas/internal/pets/openapi.json
@@ -583,12 +583,6 @@
                   },
                   "owner": {
                     "type": "integer"
-                  },
-                  "friends": {
-                    "type": "array",
-                    "items": {
-                      "type": "integer"
-                    }
                   }
                 }
               }
@@ -1208,7 +1202,55 @@
           "name"
         ]
       },
+      "Category_PetsCreate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
       "Category_PetsList": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "Category_PetsUpdate": {
         "type": "object",
         "properties": {
           "id": {
@@ -1385,6 +1427,21 @@
           "name"
         ]
       },
+      "Pet_CategoriesCreate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
       "Pet_CategoriesList": {
         "type": "object",
         "properties": {
@@ -1393,6 +1450,45 @@
           },
           "name": {
             "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "Pet_CategoriesUpdate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "Pet_FriendsCreate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer"
           }
         },
         "required": [
@@ -1424,7 +1520,45 @@
           "name"
         ]
       },
+      "Pet_OwnerCreate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "age"
+        ]
+      },
       "Pet_OwnerRead": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "age"
+        ]
+      },
+      "Pet_OwnerUpdate": {
         "type": "object",
         "properties": {
           "id": {
@@ -1544,7 +1678,55 @@
           "age"
         ]
       },
+      "User_PetsCreate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
       "User_PetsList": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nicknames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "age": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "User_PetsUpdate": {
         "type": "object",
         "properties": {
           "id": {

--- a/entoas/internal/pets/schema/pet.go
+++ b/entoas/internal/pets/schema/pet.go
@@ -60,7 +60,9 @@ func (Pet) Edges() []ent.Edge {
 			Annotations(
 				entoas.Groups("pet:list", "pet:read", "test:edge", "test:view"),
 			),
-		edge.To("friends", Pet.Type),
+		edge.To("friends", Pet.Type).Annotations(
+			entoas.Annotation{Update: entoas.OperationConfig{Policy: entoas.PolicyExclude}},
+		),
 	}
 }
 

--- a/entoas/view.go
+++ b/entoas/view.go
@@ -82,8 +82,8 @@ func Views(g *gen.Graph) (map[string]*View, error) {
 			}
 			// For every operation add a schema to use.
 			for _, op := range ops {
-				// Skip the delete operation (of course).
-				if op == OpDelete {
+				// Skip the create, delete, and update operations.
+				if op == OpCreate || op == OpDelete || op == OpUpdate {
 					continue
 				}
 				gs, err := GroupsForOperation(e.Annotations, op)


### PR DESCRIPTION
## Issue

When generating an OpenAPI spec using `entoas` from a schema that includes Edges annotated with PolicyExclude for Create or Update operations, those exclusions are being ignored by the reqBody function (it only checks for `ReadOnly` and/or `Skip` on `Field`s - there are no equivalent checks for `Edge`s).

As a simple example, if I add the following annotation to the `friends` edge on the `Pet` class (i.e., our Pets have set friends for life):

```go
edge.To("friends", Pet.Type).Annotations(
    entoas.Annotation{Update: entoas.OperationConfig{Policy: entoas.PolicyExclude}},
),
```

Without any other changes, this has no affect on the generated OpenAPI spec, and the request body for `updatePet` still includes an argument for `friends`, allowing them to be changed:
```json
"friends": {
  "type": "array",
  "items": {
    "type": "integer"
  }
}
```

## Initial Solution

My initial solution was to call `EdgeOperations` for each Edge in the schema and test whether it contains the operation currently being converted (indicating it can be exposed). If not, it excludes the Edge, excluding it from the generated schema. 

However, the current implementation of `EdgeOperations` only sets values for `Read` and `List` operations; and its not entirely clear to me whether this is intended or not. I only found two invocations of the function, [the first of which](https://github.com/kelnage/ent-contrib/blob/f180f66309eafda8b0bbf331f83b4cc2c6334ad8/entoas/generator.go#L230) is limited to looking at just the values associated with Read and List, whereas [the other](https://github.com/kelnage/ent-contrib/blob/f180f66309eafda8b0bbf331f83b4cc2c6334ad8/entoas/view.go#L79C19-L79C19) seems to assume it might receive Delete exposure information (which the current implementation won't do).

If I add in the Create, Delete and Update policies to being fetched by `EdgeOperations`, it does lead to new operations being [added to the Pets OpenAPI spec](https://github.com/kelnage/ent-contrib/commit/f180f66309eafda8b0bbf331f83b4cc2c6334ad8) (`Category_Pets(Create|Update)`, `Pet_Categories(Create|Update)`, `Pet_FriendsCreate`, `Pet_Owner(Create|Update)`, `User_Pets(Create|Update)`); which I guess the prior design of `EdgeOperations` was intended to prevent? [Excluding them in `view.go`](https://github.com/kelnage/ent-contrib/blob/bbcbf8dc4c5ea72ec50ace0fa0b09d8de3e507a4/entoas/view.go#L86) results in effectively the same schema being generated (modulo the intended exclusion of the `friends` attribute from the `updatePet` endpoint).

## Question

I'm not fully convinced that the Operation Policy approach is the correct one for the underlying problem for excluding Edges from request bodies (I have found reasoning about the policies in the context of edges is somewhat challenging - e.g., I'm not entirely sure why the `Unique` annotation is interpreted as allowing Read operations by not List). In contrast, Fields have the `Skip` annotation, where its meaning is more clear - would it make more sense to add in a similar mechanism to achieve my goal? Or do you think my approach in this PR appropriate?