### PR TITLE
fix: rename variable when iterating through p.order in toCursor template

### DIFF
--- a/entgql/internal/todo/ent/gql_pagination.go
+++ b/entgql/internal/todo/ent/gql_pagination.go
@@ -476,8 +476,8 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(c).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(c).Value)
 	}
 	return Cursor{ID: c.ID, Value: cs}
 }
@@ -1163,8 +1163,8 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(gr).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(gr).Value)
 	}
 	return Cursor{ID: gr.ID, Value: cs}
 }
@@ -1990,8 +1990,8 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(t).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(t).Value)
 	}
 	return Cursor{ID: t.ID, Value: cs}
 }

--- a/entgql/internal/todogotype/ent/gql_pagination.go
+++ b/entgql/internal/todogotype/ent/gql_pagination.go
@@ -474,8 +474,8 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(c).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(c).Value)
 	}
 	return Cursor{ID: c.marshalID(), Value: cs}
 }
@@ -1639,8 +1639,8 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(t).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(t).Value)
 	}
 	return Cursor{ID: t.ID, Value: cs}
 }

--- a/entgql/internal/todopulid/ent/gql_pagination.go
+++ b/entgql/internal/todopulid/ent/gql_pagination.go
@@ -474,8 +474,8 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(c).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(c).Value)
 	}
 	return Cursor{ID: c.ID, Value: cs}
 }
@@ -1143,8 +1143,8 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(gr).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(gr).Value)
 	}
 	return Cursor{ID: gr.ID, Value: cs}
 }
@@ -1427,8 +1427,8 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(t).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(t).Value)
 	}
 	return Cursor{ID: t.ID, Value: cs}
 }

--- a/entgql/internal/todouuid/ent/gql_pagination.go
+++ b/entgql/internal/todouuid/ent/gql_pagination.go
@@ -474,8 +474,8 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(c).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(c).Value)
 	}
 	return Cursor{ID: c.ID, Value: cs}
 }
@@ -1143,8 +1143,8 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(gr).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(gr).Value)
 	}
 	return Cursor{ID: gr.ID, Value: cs}
 }
@@ -1427,8 +1427,8 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
 	cs := make([]any, 0, len(p.order))
-	for _, o := range p.order {
-		cs = append(cs, o.Field.toCursor(t).Value)
+	for _, po := range p.order {
+		cs = append(cs, po.Field.toCursor(t).Value)
 	}
 	return Cursor{ID: t.ID, Value: cs}
 }

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -272,8 +272,8 @@ func (p *{{ $pager }}) applyFilter(query *{{ $query }}) (*{{ $query }}, error) {
 func (p *{{ $pager }}) toCursor({{ $r }} *{{ $name }}) Cursor {
 	{{- if $multiOrder }}
 		cs := make([]any, 0, len(p.order))
-		for _, o := range p.order {
-			cs = append(cs, o.Field.toCursor({{ $r }}).Value)
+		for _, po := range p.order {
+			cs = append(cs, po.Field.toCursor({{ $r }}).Value)
 		}
 		{{- $marshalID := and $idType.Mixed (gqlMarshaler $node.ID) }}
 		return Cursor{ID: {{ $r }}.{{ if $marshalID }}marshalID(){{ else }}ID{{ end }}, Value: cs}


### PR DESCRIPTION
According to https://github.com/ent/ent/issues/3601, I've found this error too when my table's name starts with 'O'. 
It seems variables' name are conflicting; the argument of toCursor function and the one for iterating through p.order.
I've renamed the variable for iterating through p.order to 'po' in a template. 