### PR TITLE
fix edge comment generation when relayConnection is enabled

### DIFF
--- a/entgql/internal/todo/ent.graphql
+++ b/entgql/internal/todo/ent.graphql
@@ -712,7 +712,9 @@ type Todo implements Node {
   init: Map
   custom: [Custom!]
   customp: [Custom]
+  """The parent of the todo"""
   parent: Todo
+  """The children of the todo"""
   children(
     """Returns the elements in the list that come after the specified cursor."""
     after: Cursor
@@ -923,6 +925,7 @@ type User implements Node {
   username: UUID!
   requiredMetadata: Map!
   metadata: Map
+  """The groups of the user"""
   groups(
     """Returns the elements in the list that come after the specified cursor."""
     after: Cursor

--- a/entgql/internal/todo/ent/schema/todo.go
+++ b/entgql/internal/todo/ent/schema/todo.go
@@ -93,6 +93,7 @@ func (Todo) Fields() []ent.Field {
 func (Todo) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("children", Todo.Type).
+			Comment("The children of the todo").
 			Annotations(
 				entgql.RelayConnection(),
 				// For non-unique edges, the order field can be only on edge count.
@@ -100,6 +101,7 @@ func (Todo) Edges() []ent.Edge {
 				entgql.OrderField("CHILDREN_COUNT"),
 			).
 			From("parent").
+			Comment("The parent of the todo").
 			Annotations(
 				// For unique edges, the order field can be on the edge field that is defined
 				// as entgql.OrderField. The convention is "UPPER(<edge-name>)_<gql-order-field>".

--- a/entgql/internal/todo/ent/todo.go
+++ b/entgql/internal/todo/ent/todo.go
@@ -64,9 +64,9 @@ type Todo struct {
 
 // TodoEdges holds the relations/edges for other nodes in the graph.
 type TodoEdges struct {
-	// Parent holds the value of the parent edge.
+	// The parent of the todo
 	Parent *Todo `json:"parent,omitempty"`
-	// Children holds the value of the children edge.
+	// The children of the todo
 	Children []*Todo `json:"children,omitempty"`
 	// Category holds the value of the category edge.
 	Category *Category `json:"category,omitempty"`

--- a/entgql/internal/todogotype/ent/todo.go
+++ b/entgql/internal/todogotype/ent/todo.go
@@ -64,9 +64,9 @@ type Todo struct {
 
 // TodoEdges holds the relations/edges for other nodes in the graph.
 type TodoEdges struct {
-	// Parent holds the value of the parent edge.
+	// The parent of the todo
 	Parent *Todo `json:"parent,omitempty"`
-	// Children holds the value of the children edge.
+	// The children of the todo
 	Children []*Todo `json:"children,omitempty"`
 	// Category holds the value of the category edge.
 	Category *Category `json:"category,omitempty"`

--- a/entgql/internal/todopulid/ent/todo.go
+++ b/entgql/internal/todopulid/ent/todo.go
@@ -64,9 +64,9 @@ type Todo struct {
 
 // TodoEdges holds the relations/edges for other nodes in the graph.
 type TodoEdges struct {
-	// Parent holds the value of the parent edge.
+	// The parent of the todo
 	Parent *Todo `json:"parent,omitempty"`
-	// Children holds the value of the children edge.
+	// The children of the todo
 	Children []*Todo `json:"children,omitempty"`
 	// Category holds the value of the category edge.
 	Category *Category `json:"category,omitempty"`

--- a/entgql/internal/todouuid/ent/todo.go
+++ b/entgql/internal/todouuid/ent/todo.go
@@ -64,9 +64,9 @@ type Todo struct {
 
 // TodoEdges holds the relations/edges for other nodes in the graph.
 type TodoEdges struct {
-	// Parent holds the value of the parent edge.
+	// The parent of the todo
 	Parent *Todo `json:"parent,omitempty"`
-	// Children holds the value of the children edge.
+	// The children of the todo
 	Children []*Todo `json:"children,omitempty"`
 	// Category holds the value of the category edge.
 	Category *Category `json:"category,omitempty"`

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -450,6 +450,9 @@ func (e *schemaGenerator) buildEdge(node *gen.Type, edge *gen.Edge, edgeAnt *Ann
 				ConnectionField(name, len(orderFields) > 0, ant.MultiOrder,
 					e.genWhereInput && !edgeAnt.Skip.Is(SkipWhereInput) && !ant.Skip.Is(SkipWhereInput),
 				)
+			// The ConnectionField above method creates a new FieldDefinition object without Description
+			// therefore, the Description field needs to be assigned
+			fieldDef.Description = edge.Comment()
 		default:
 			fieldDef.Type = listNamedType(gqlType, edge.Optional)
 		}


### PR DESCRIPTION
when the `edgeAnt.RelayConnection` is true, the `Description` field was overwritten as an empty string. Therefore, the comment was not displayed in the  `ein.graphql` schema file.