### PR TITLE
add support for through edges

### DIFF
--- a/schemast/edge.go
+++ b/schemast/edge.go
@@ -27,6 +27,9 @@ import (
 // to construct it.
 func Edge(desc *edge.Descriptor) (*ast.CallExpr, error) {
 	builder := newEdgeCall(desc)
+	if desc.Through != nil {
+		builder.method("Through", strLit(desc.Through.N), selectorLit(desc.Through.T, "Type"))
+	}
 	if desc.RefName != "" {
 		builder.method("Ref", strLit(desc.RefName))
 	}

--- a/schemast/edge_test.go
+++ b/schemast/edge_test.go
@@ -40,6 +40,11 @@ func TestFromEdgeDescriptor(t *testing.T) {
 			expected: `edge.To("entity", Entity.Type)`,
 		},
 		{
+			name:     "through",
+			edge:     edge.To("entity", Entity.Type).Through("entity", Entity.Type),
+			expected: `edge.To("entity", Entity.Type).Through("entity", Entity.Type)`,
+		},
+		{
 			name:     "inverse",
 			edge:     edge.From("entity", Entity.Type).Ref("related"),
 			expected: `edge.From("entity", Entity.Type).Ref("related")`,


### PR DESCRIPTION
Just a simple addition to allow schemast to support through edges. Usage is `e.Descriptor().Through = &struct{ N, T string }{N: throughName, T: throughType}`. If this is accepted happy to update the docs page too. 