### PR TITLE
entgql: improve var name collision avoidance in toCursor

### DIFF
--- a/entgql/internal/todo/ent/gql_pagination.go
+++ b/entgql/internal/todo/ent/gql_pagination.go
@@ -476,11 +476,11 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 }
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(c).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(c).Value)
 	}
-	return Cursor{ID: c.ID, Value: cs}
+	return Cursor{ID: c.ID, Value: cs_}
 }
 
 func (p *categoryPager) applyCursors(query *CategoryQuery, after, before *Cursor) (*CategoryQuery, error) {
@@ -1165,11 +1165,11 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 }
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(gr).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(gr).Value)
 	}
-	return Cursor{ID: gr.ID, Value: cs}
+	return Cursor{ID: gr.ID, Value: cs_}
 }
 
 func (p *groupPager) applyCursors(query *GroupQuery, after, before *Cursor) (*GroupQuery, error) {
@@ -1995,11 +1995,11 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 }
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(t).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(t).Value)
 	}
-	return Cursor{ID: t.ID, Value: cs}
+	return Cursor{ID: t.ID, Value: cs_}
 }
 
 func (p *todoPager) applyCursors(query *TodoQuery, after, before *Cursor) (*TodoQuery, error) {

--- a/entgql/internal/todogotype/ent/gql_pagination.go
+++ b/entgql/internal/todogotype/ent/gql_pagination.go
@@ -474,11 +474,11 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 }
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(c).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(c).Value)
 	}
-	return Cursor{ID: c.marshalID(), Value: cs}
+	return Cursor{ID: c.marshalID(), Value: cs_}
 }
 
 func (p *categoryPager) applyCursors(query *CategoryQuery, after, before *Cursor) (*CategoryQuery, error) {
@@ -1643,11 +1643,11 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 }
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(t).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(t).Value)
 	}
-	return Cursor{ID: t.ID, Value: cs}
+	return Cursor{ID: t.ID, Value: cs_}
 }
 
 func (p *todoPager) applyCursors(query *TodoQuery, after, before *Cursor) (*TodoQuery, error) {

--- a/entgql/internal/todopulid/ent/gql_pagination.go
+++ b/entgql/internal/todopulid/ent/gql_pagination.go
@@ -474,11 +474,11 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 }
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(c).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(c).Value)
 	}
-	return Cursor{ID: c.ID, Value: cs}
+	return Cursor{ID: c.ID, Value: cs_}
 }
 
 func (p *categoryPager) applyCursors(query *CategoryQuery, after, before *Cursor) (*CategoryQuery, error) {
@@ -1145,11 +1145,11 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 }
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(gr).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(gr).Value)
 	}
-	return Cursor{ID: gr.ID, Value: cs}
+	return Cursor{ID: gr.ID, Value: cs_}
 }
 
 func (p *groupPager) applyCursors(query *GroupQuery, after, before *Cursor) (*GroupQuery, error) {
@@ -1430,11 +1430,11 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 }
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(t).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(t).Value)
 	}
-	return Cursor{ID: t.ID, Value: cs}
+	return Cursor{ID: t.ID, Value: cs_}
 }
 
 func (p *todoPager) applyCursors(query *TodoQuery, after, before *Cursor) (*TodoQuery, error) {

--- a/entgql/internal/todouuid/ent/gql_pagination.go
+++ b/entgql/internal/todouuid/ent/gql_pagination.go
@@ -474,11 +474,11 @@ func (p *categoryPager) applyFilter(query *CategoryQuery) (*CategoryQuery, error
 }
 
 func (p *categoryPager) toCursor(c *Category) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(c).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(c).Value)
 	}
-	return Cursor{ID: c.ID, Value: cs}
+	return Cursor{ID: c.ID, Value: cs_}
 }
 
 func (p *categoryPager) applyCursors(query *CategoryQuery, after, before *Cursor) (*CategoryQuery, error) {
@@ -1145,11 +1145,11 @@ func (p *groupPager) applyFilter(query *GroupQuery) (*GroupQuery, error) {
 }
 
 func (p *groupPager) toCursor(gr *Group) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(gr).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(gr).Value)
 	}
-	return Cursor{ID: gr.ID, Value: cs}
+	return Cursor{ID: gr.ID, Value: cs_}
 }
 
 func (p *groupPager) applyCursors(query *GroupQuery, after, before *Cursor) (*GroupQuery, error) {
@@ -1430,11 +1430,11 @@ func (p *todoPager) applyFilter(query *TodoQuery) (*TodoQuery, error) {
 }
 
 func (p *todoPager) toCursor(t *Todo) Cursor {
-	cs := make([]any, 0, len(p.order))
-	for _, po := range p.order {
-		cs = append(cs, po.Field.toCursor(t).Value)
+	cs_ := make([]any, 0, len(p.order))
+	for _, o_ := range p.order {
+		cs_ = append(cs_, o_.Field.toCursor(t).Value)
 	}
-	return Cursor{ID: t.ID, Value: cs}
+	return Cursor{ID: t.ID, Value: cs_}
 }
 
 func (p *todoPager) applyCursors(query *TodoQuery, after, before *Cursor) (*TodoQuery, error) {

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -271,12 +271,12 @@ func (p *{{ $pager }}) applyFilter(query *{{ $query }}) (*{{ $query }}, error) {
 {{ $r := $node.Receiver }}
 func (p *{{ $pager }}) toCursor({{ $r }} *{{ $name }}) Cursor {
 	{{- if $multiOrder }}
-		cs := make([]any, 0, len(p.order))
-		for _, po := range p.order {
-			cs = append(cs, po.Field.toCursor({{ $r }}).Value)
+		cs_ := make([]any, 0, len(p.order))
+		for _, o_ := range p.order {
+			cs_ = append(cs_, o_.Field.toCursor({{ $r }}).Value)
 		}
 		{{- $marshalID := and $idType.Mixed (gqlMarshaler $node.ID) }}
-		return Cursor{ID: {{ $r }}.{{ if $marshalID }}marshalID(){{ else }}ID{{ end }}, Value: cs}
+		return Cursor{ID: {{ $r }}.{{ if $marshalID }}marshalID(){{ else }}ID{{ end }}, Value: cs_}
 	{{- else }}
 		return p.order.Field.toCursor({{ $r }})
 	{{- end }}


### PR DESCRIPTION
Improves variable name collision avoidance in the `toCursor` method of the pager types in the `gql_pagination` template by suffixing all hard-coded variables names with an underscore.

Address the issue that was the target of #488 and #538. PR #538 fixed the issue for types that start with "O" but broke it for types that start with "Po" (e.g. "Post") or that are two words with the initials "PO" (e.g. "PostOffice"). The issue is also present for types that have the initials "CS" (e.g. "CourseSection"). My fix here puts an underscore as a suffix on all the internal variables so that variable name collision is not possible.

It might be better to opt out of dynamic variables for the argument altogether or updating the variable name generator to accept more context about names to avoid, but this seemed the minimal change to solve the issue. I'll leave it to you guys to decide if a bigger refactor is desired.