### PR TITLE
fix: entoas.GetConfig() has incorrect nil checks against configuration

### DIFF
--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -234,7 +234,7 @@ func (c *Config) Decode(o interface{}) error {
 // GetConfig loads the entoas.Config from the given *gen.Config object.
 func GetConfig(cfg *gen.Config) (*Config, error) {
 	c := &Config{}
-	if cfg == nil && cfg.Annotations == nil && cfg.Annotations[c.Name()] == nil {
+	if cfg != nil && cfg.Annotations != nil && cfg.Annotations[c.Name()] == nil {
 		return nil, errors.New("entoas extension configuration not found")
 	}
 	return c, c.Decode(cfg.Annotations[c.Name()])

--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -213,7 +213,7 @@ func (ex *Extension) generate(next gen.Generator) gen.Generator {
 			_, err = ex.out.Write(b)
 			return err
 		}
-		return os.WriteFile(filepath.Join(g.Target, "openapi.json"), b, 0644)
+		return os.WriteFile(filepath.Join(g.Target, "openapi.json"), b, 0o644)
 	})
 }
 

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -610,32 +610,32 @@ func NodeOperations(n *gen.Type) ([]Operation, error) {
 			return []Operation{OpCreate, OpRead, OpUpdate, OpDelete, OpList}, nil
 		}
 		return nil, nil
-	} else {
-		// An operation gets exposed if it is either
-		// - annotated with PolicyExpose or
-		// - not annotated with PolicyExclude and the DefaultPolicy is PolicyExpose.
-		if err := ant.Decode(n.Annotations[ant.Name()]); err != nil {
-			return nil, err
-		}
-		var ops []Operation
-		for op, opn := range map[Operation]OperationConfig{
-			OpCreate: ant.Create,
-			OpRead:   ant.Read,
-			OpUpdate: ant.Update,
-			OpDelete: ant.Delete,
-			OpList:   ant.List,
-		} {
-			// If the operation is explicitly annotated to be exposed do so.
-			if opn.Policy == PolicyExpose || (opn.Policy == PolicyNone && c.DefaultPolicy == PolicyExpose) {
-				ops = append(ops, op)
-				continue
-			}
-		}
-		sort.Slice(ops, func(i, j int) bool {
-			return ops[i] < ops[j]
-		})
-		return ops, nil
 	}
+
+	// An operation gets exposed if it is either
+	// - annotated with PolicyExpose or
+	// - not annotated with PolicyExclude and the DefaultPolicy is PolicyExpose.
+	if err := ant.Decode(n.Annotations[ant.Name()]); err != nil {
+		return nil, err
+	}
+	var ops []Operation
+	for op, opn := range map[Operation]OperationConfig{
+		OpCreate: ant.Create,
+		OpRead:   ant.Read,
+		OpUpdate: ant.Update,
+		OpDelete: ant.Delete,
+		OpList:   ant.List,
+	} {
+		// If the operation is explicitly annotated to be exposed do so.
+		if opn.Policy == PolicyExpose || (opn.Policy == PolicyNone && c.DefaultPolicy == PolicyExpose) {
+			ops = append(ops, op)
+			continue
+		}
+	}
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i] < ops[j]
+	})
+	return ops, nil
 }
 
 // EdgeOperations returns the list of operations to expose for this edge.
@@ -650,36 +650,35 @@ func EdgeOperations(e *gen.Edge) ([]Operation, error) {
 		if c.DefaultPolicy == PolicyExpose {
 			if e.Unique {
 				return []Operation{OpRead}, nil
-			} else {
-				return []Operation{OpList}, nil
 			}
+			return []Operation{OpList}, nil
 		}
 		return nil, nil
-	} else {
-		// An edge-operation gets exposed if it is either
-		// - annotated with PolicyExpose or
-		// - not annotated with PolicyExclude and the DefaultPolicy is PolicyExpose.
-		if err := ant.Decode(e.Annotations[ant.Name()]); err != nil {
-			return nil, err
-		}
-		var ops []Operation
-		m := make(map[Operation]OperationConfig)
-		if e.Unique {
-			m[OpRead] = ant.Read
-		} else {
-			m[OpList] = ant.List
-		}
-		for op, opn := range m {
-			if opn.Policy == PolicyExpose || (opn.Policy == PolicyNone && c.DefaultPolicy == PolicyExpose) {
-				ops = append(ops, op)
-				continue
-			}
-		}
-		sort.Slice(ops, func(i, j int) bool {
-			return ops[i] < ops[j]
-		})
-		return ops, nil
 	}
+
+	// An edge-operation gets exposed if it is either
+	// - annotated with PolicyExpose or
+	// - not annotated with PolicyExclude and the DefaultPolicy is PolicyExpose.
+	if err := ant.Decode(e.Annotations[ant.Name()]); err != nil {
+		return nil, err
+	}
+	var ops []Operation
+	m := make(map[Operation]OperationConfig)
+	if e.Unique {
+		m[OpRead] = ant.Read
+	} else {
+		m[OpList] = ant.List
+	}
+	for op, opn := range m {
+		if opn.Policy == PolicyExpose || (opn.Policy == PolicyNone && c.DefaultPolicy == PolicyExpose) {
+			ops = append(ops, op)
+			continue
+		}
+	}
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i] < ops[j]
+	})
+	return ops, nil
 }
 
 // reqBody returns the request body for the given node and operation.


### PR DESCRIPTION
Includes a few other minor lint related items (new file perm syntax, early returns, etc).