### PR TITLE
feat(entoas): add field descriptions and fix examples

### DIFF
--- a/entoas/annotation.go
+++ b/entoas/annotation.go
@@ -29,7 +29,7 @@ type (
 		// Groups holds the serialization groups to use on this field / edge.
 		Groups serialization.Groups
 		// OpenAPI Specification example value for a schema field.
-		Example interface{}
+		Example any
 		// OpenAPI Specification schema to use for a schema field.
 		Schema *ogen.Schema
 		// Create has meta information about a creation operation.
@@ -71,8 +71,9 @@ func OperationPolicy(p Policy) OperationConfigOption {
 	return func(c *OperationConfig) { c.Policy = p }
 }
 
-// Example returns an example annotation.
-func Example(v interface{}) Annotation { return Annotation{Example: v} }
+// Example returns an example annotation on a field. This is meant to show an example value of
+// what the field would look like.
+func Example(v any) Annotation { return Annotation{Example: v} }
 
 // Schema returns a Schema annotation.
 func Schema(s *ogen.Schema) Annotation { return Annotation{Schema: s} }
@@ -166,7 +167,7 @@ func (op *OperationConfig) merge(other OperationConfig) {
 }
 
 // Decode from ent.
-func (a *Annotation) Decode(o interface{}) error {
+func (a *Annotation) Decode(o any) error {
 	buf, err := json.Marshal(o)
 	if err != nil {
 		return err

--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -224,7 +224,7 @@ func (c Config) Name() string {
 }
 
 // Decode from ent.
-func (c *Config) Decode(o interface{}) error {
+func (c *Config) Decode(o any) error {
 	buf, err := json.Marshal(o)
 	if err != nil {
 		return err

--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -71,8 +72,8 @@ type (
 func NewExtension(opts ...ExtensionOption) (*Extension, error) {
 	ex := &Extension{config: &Config{
 		DefaultPolicy:   PolicyExpose,
-		MinItemsPerPage: one,
-		MaxItemsPerPage: maxu8,
+		MinItemsPerPage: 1,
+		MaxItemsPerPage: math.MaxUint8,
 	}}
 	for _, opt := range opts {
 		if err := opt(ex); err != nil {

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -444,7 +444,7 @@ func listOp(spec *ogen.Spec, n *gen.Type) (*ogen.Operation, error) {
 				InQuery().
 				SetName("page").
 				SetDescription("what page to render").
-				SetSchema(ogen.Int().SetMinimum(&one)),
+				SetSchema(ogen.Int().SetMinimum(ptr(int64(1)))),
 			ogen.NewParameter().
 				InQuery().
 				SetName("itemsPerPage").
@@ -524,40 +524,57 @@ func property(f *gen.Field) (*ogen.Property, error) {
 	return ogen.NewProperty().SetName(f.Name).SetSchema(s), nil
 }
 
-var (
-	zero   int64
-	one    int64 = 1
-	min8   int64 = math.MinInt8
-	max8   int64 = math.MaxInt8
-	maxu8  int64 = math.MaxUint8
-	min16  int64 = math.MinInt16
-	max16  int64 = math.MaxInt16
-	maxu16 int64 = math.MaxUint16
-	maxu32 int64 = math.MaxUint32
-	types        = map[string]*ogen.Schema{
-		"bool":      ogen.Bool(),
-		"time.Time": ogen.DateTime(),
-		"string":    ogen.String(),
-		"[]byte":    ogen.Bytes(),
-		"uuid.UUID": ogen.UUID(),
-		"int":       ogen.Int(),
-		"int8":      ogen.Int32().SetMinimum(&min8).SetMaximum(&max8),
-		"int16":     ogen.Int32().SetMinimum(&min16).SetMaximum(&max16),
-		"int32":     ogen.Int32(),
-		"uint":      ogen.Int64().SetMinimum(&zero).SetMaximum(&maxu32),
-		"uint8":     ogen.Int32().SetMinimum(&zero).SetMaximum(&maxu8),
-		"uint16":    ogen.Int32().SetMinimum(&zero).SetMaximum(&maxu16),
-		"uint32":    ogen.Int64().SetMinimum(&zero).SetMaximum(&maxu32),
-		"int64":     ogen.Int64(),
-		"uint64":    ogen.Int64().SetMinimum(&zero),
-		"float32":   ogen.Float(),
-		"float64":   ogen.Double(),
+// ptr returns a pointer to v, for the purposes of base types (int, string, etc).
+func ptr[T any](v T) *T {
+	return &v
+}
+
+// mapTypeToSchema returns an ogen.Schema for the given gen.Field, if it exists.
+// returns nil if the type is not supported.
+func mapTypeToSchema(baseType string) *ogen.Schema {
+	switch baseType {
+	case "bool":
+		return ogen.Bool()
+	case "time.Time":
+		return ogen.DateTime()
+	case "string":
+		return ogen.String()
+	case "[]byte":
+		return ogen.Bytes()
+	case "uuid.UUID":
+		return ogen.UUID()
+	case "int":
+		return ogen.Int()
+	case "int8":
+		return ogen.Int32().SetMinimum(ptr(int64(math.MinInt8))).SetMaximum(ptr(int64(math.MaxInt8)))
+	case "int16":
+		return ogen.Int32().SetMinimum(ptr(int64(math.MinInt16))).SetMaximum(ptr(int64(math.MaxInt16)))
+	case "int32":
+		return ogen.Int32().SetMinimum(ptr(int64(math.MinInt32))).SetMaximum(ptr(int64(math.MaxInt32)))
+	case "int64":
+		return ogen.Int64().SetMinimum(ptr(int64(math.MinInt64))).SetMaximum(ptr(int64(math.MaxInt64)))
+	case "uint":
+		return ogen.Int64().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint32)))
+	case "uint8":
+		return ogen.Int32().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint8)))
+	case "uint16":
+		return ogen.Int32().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint16)))
+	case "uint32":
+		return ogen.Int64().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint32)))
+	case "uint64":
+		return ogen.Int64().SetMinimum(ptr(int64(0)))
+	case "float32":
+		return ogen.Float()
+	case "float64":
+		return ogen.Double()
+	default:
+		return nil
 	}
-)
+}
 
 // OgenSchema returns the ogen.Schema to use for the given gen.Field.
 func OgenSchema(f *gen.Field) (*ogen.Schema, error) {
-	// If there is a custom property given on the field use it.
+	// If there is a custom property/schema given on the field, use it.
 	ant, err := FieldAnnotation(f)
 	if err != nil {
 		return nil, err
@@ -565,6 +582,10 @@ func OgenSchema(f *gen.Field) (*ogen.Schema, error) {
 	if ant.Schema != nil {
 		return ant.Schema, nil
 	}
+
+	var schema *ogen.Schema
+	baseType := f.Type.String()
+
 	// Enum values need special case.
 	if f.IsEnum() {
 		var d json.RawMessage
@@ -581,20 +602,31 @@ func OgenSchema(f *gen.Field) (*ogen.Schema, error) {
 				return nil, err
 			}
 		}
-		return ogen.String().AsEnum(d, vs...), nil
+		schema = ogen.String().AsEnum(d, vs...)
 	}
-	s := f.Type.String()
-	// Handle slice types.
-	if strings.HasPrefix(s, "[]") {
-		if t, ok := types[s[2:]]; ok {
-			return t.AsArray(), nil
+
+	if schema == nil {
+		if strings.HasPrefix(baseType, "[]") { // Handle slice types.
+			schema = mapTypeToSchema(baseType[2:])
+			if schema != nil {
+				schema = schema.AsArray()
+			}
+		}
+
+		if schema == nil {
+			schema = mapTypeToSchema(baseType)
 		}
 	}
-	t, ok := types[s]
-	if !ok {
-		return nil, fmt.Errorf("no OAS-type exists for type %q of field %s", s, f.StructField())
+
+	if schema == nil {
+		return nil, fmt.Errorf("no OAS-type exists for type %q of field %s", baseType, f.StructField())
 	}
-	return t, nil
+
+	if schema.Description == "" {
+		schema.Description = f.Comment()
+	}
+
+	return schema, nil
 }
 
 // NodeOperations returns the list of operations to expose for this node.
@@ -732,21 +764,6 @@ func reqBody(n *gen.Type, op Operation, allowClientUUIDs bool) (*ogen.RequestBod
 	req.SetJSONContent(c)
 	return req, nil
 }
-
-// // exampleValue returns the user defined example value for the ent schema field.
-// func exampleValue(f *gen.Field) (interface{}, error) {
-// 	a, err := FieldAnnotation(f)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	if a != nil && a.Example != nil {
-// 		return a.Example, err
-// 	}
-// 	if f.IsEnum() {
-// 		return f.EnumValues()[0], nil
-// 	}
-// 	return nil, nil
-// }
 
 // contains checks if a string slice contains the given value.
 func contains(xs []Operation, s Operation) bool {

--- a/entoas/generator.go
+++ b/entoas/generator.go
@@ -626,6 +626,13 @@ func OgenSchema(f *gen.Field) (*ogen.Schema, error) {
 		schema.Description = f.Comment()
 	}
 
+	if ant.Example != nil {
+		schema.Example, err = json.Marshal(ant.Example)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal example for field %s: %w", f.StructField(), err)
+		}
+	}
+
 	return schema, nil
 }
 

--- a/entoas/generator_test.go
+++ b/entoas/generator_test.go
@@ -122,7 +122,7 @@ func DefaultLink() *Link {
 }
 
 // Scan implements the Scanner interface.
-func (l *Link) Scan(value interface{}) (err error) {
+func (l *Link) Scan(value any) (err error) {
 	switch v := value.(type) {
 	case nil:
 	case []byte:

--- a/entoas/generator_test.go
+++ b/entoas/generator_test.go
@@ -18,6 +18,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"testing"
@@ -36,15 +37,15 @@ func TestOgenSchema(t *testing.T) {
 	for d, ex := range map[*entfield.Descriptor]*ogen.Schema{
 		// Numeric
 		entfield.Int("int").Descriptor():         ogen.Int(),
-		entfield.Int8("int8").Descriptor():       ogen.Int32().SetMinimum(&min8).SetMaximum(&max8),
-		entfield.Int16("int16").Descriptor():     ogen.Int32().SetMinimum(&min16).SetMaximum(&max16),
-		entfield.Int32("int32").Descriptor():     ogen.Int32(),
-		entfield.Int64("int64").Descriptor():     ogen.Int64(),
-		entfield.Uint("uint").Descriptor():       ogen.Int64().SetMinimum(&zero).SetMaximum(&maxu32),
-		entfield.Uint8("uint8").Descriptor():     ogen.Int32().SetMinimum(&zero).SetMaximum(&maxu8),
-		entfield.Uint16("uint16").Descriptor():   ogen.Int32().SetMinimum(&zero).SetMaximum(&maxu16),
-		entfield.Uint32("uint32").Descriptor():   ogen.Int64().SetMinimum(&zero).SetMaximum(&maxu32),
-		entfield.Uint64("uint64").Descriptor():   ogen.Int64().SetMinimum(&zero),
+		entfield.Int8("int8").Descriptor():       ogen.Int32().SetMinimum(ptr(int64(math.MinInt8))).SetMaximum(ptr(int64(math.MaxInt8))),
+		entfield.Int16("int16").Descriptor():     ogen.Int32().SetMinimum(ptr(int64(math.MinInt16))).SetMaximum(ptr(int64(math.MaxInt16))),
+		entfield.Int32("int32").Descriptor():     ogen.Int32().SetMinimum(ptr(int64(math.MinInt32))).SetMaximum(ptr(int64(math.MaxInt32))),
+		entfield.Int64("int64").Descriptor():     ogen.Int64().SetMinimum(ptr(int64(math.MinInt64))).SetMaximum(ptr(int64(math.MaxInt64))),
+		entfield.Uint("uint").Descriptor():       ogen.Int64().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint32))),
+		entfield.Uint8("uint8").Descriptor():     ogen.Int32().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint8))),
+		entfield.Uint16("uint16").Descriptor():   ogen.Int32().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint16))),
+		entfield.Uint32("uint32").Descriptor():   ogen.Int64().SetMinimum(ptr(int64(0))).SetMaximum(ptr(int64(math.MaxUint32))),
+		entfield.Uint64("uint64").Descriptor():   ogen.Int64().SetMinimum(ptr(int64(0))),
 		entfield.Float32("float32").Descriptor(): ogen.Float(),
 		entfield.Float("float64").Descriptor():   ogen.Double(),
 		// Basic


### PR DESCRIPTION
This PR does two things:
- For all ent fields, the description field is populated in the ogen schema.
  - Had to move away from the `types` map, because this was using the same fields, and changing the contents was impacting all fields of the same type. Don't see any noticeable performance difference -- not sure if this was intentional before or not.
  - Added `ptr[T any](v) *v` to help with code-duplication and should help with all of the pointer-to-base-types issues.
  - Fixes some cases of min/max not being properly applied.
- The `Example()` annotation now works as expected. Previously, adding that annotation to any field, edge, or schema, didn't seem to have any affect.