### PR TITLE
entgql: Prevent name collision in CollectFields

### DIFF
--- a/entgql/internal/todo/ent/gql_collection.go
+++ b/entgql/internal/todo/ent/gql_collection.go
@@ -37,11 +37,11 @@ import (
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...string) (*BillProductQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return bp, nil
 	}
-	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return bp, nil
@@ -114,11 +114,11 @@ func newBillProductPaginateArgs(rv map[string]any) *billproductPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) (*CategoryQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return c, nil
 	}
-	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -421,11 +421,11 @@ func newCategoryPaginateArgs(rv map[string]any) *categoryPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string) (*FriendshipQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return f, nil
 	}
-	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return f, nil
@@ -528,11 +528,11 @@ func newFriendshipPaginateArgs(rv map[string]any) *friendshipPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*GroupQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return gr, nil
 	}
-	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return gr, nil
@@ -688,11 +688,11 @@ func newGroupPaginateArgs(rv map[string]any) *groupPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (otm *OneToManyQuery) CollectFields(ctx context.Context, satisfies ...string) (*OneToManyQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return otm, nil
 	}
-	if err := otm.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := otm.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return otm, nil
@@ -810,11 +810,11 @@ func newOneToManyPaginateArgs(rv map[string]any) *onetomanyPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (pr *ProjectQuery) CollectFields(ctx context.Context, satisfies ...string) (*ProjectQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return pr, nil
 	}
-	if err := pr.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := pr.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return pr, nil
@@ -949,11 +949,11 @@ func newProjectPaginateArgs(rv map[string]any) *projectPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*TodoQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return t, nil
 	}
-	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -1194,11 +1194,11 @@ func newTodoPaginateArgs(rv map[string]any) *todoPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*UserQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return u, nil
 	}
-	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -1573,11 +1573,11 @@ func newUserPaginateArgs(rv map[string]any) *userPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (w *WorkspaceQuery) CollectFields(ctx context.Context, satisfies ...string) (*WorkspaceQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return w, nil
 	}
-	if err := w.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := w.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return w, nil

--- a/entgql/internal/todofed/ent/gql_collection.go
+++ b/entgql/internal/todofed/ent/gql_collection.go
@@ -27,11 +27,11 @@ import (
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) (*CategoryQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return c, nil
 	}
-	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -151,11 +151,11 @@ func newCategoryPaginateArgs(rv map[string]any) *categoryPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*TodoQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return t, nil
 	}
-	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return t, nil

--- a/entgql/internal/todogotype/ent/gql_collection.go
+++ b/entgql/internal/todogotype/ent/gql_collection.go
@@ -36,11 +36,11 @@ import (
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...string) (*BillProductQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return bp, nil
 	}
-	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return bp, nil
@@ -113,11 +113,11 @@ func newBillProductPaginateArgs(rv map[string]any) *billproductPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) (*CategoryQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return c, nil
 	}
-	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -420,11 +420,11 @@ func newCategoryPaginateArgs(rv map[string]any) *categoryPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string) (*FriendshipQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return f, nil
 	}
-	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return f, nil
@@ -527,11 +527,11 @@ func newFriendshipPaginateArgs(rv map[string]any) *friendshipPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*GroupQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return gr, nil
 	}
-	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return gr, nil
@@ -687,11 +687,11 @@ func newGroupPaginateArgs(rv map[string]any) *groupPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (pe *PetQuery) CollectFields(ctx context.Context, satisfies ...string) (*PetQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return pe, nil
 	}
-	if err := pe.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := pe.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return pe, nil
@@ -754,11 +754,11 @@ func newPetPaginateArgs(rv map[string]any) *petPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*TodoQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return t, nil
 	}
-	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -999,11 +999,11 @@ func newTodoPaginateArgs(rv map[string]any) *todoPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*UserQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return u, nil
 	}
-	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return u, nil

--- a/entgql/internal/todopulid/ent/gql_collection.go
+++ b/entgql/internal/todopulid/ent/gql_collection.go
@@ -35,11 +35,11 @@ import (
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...string) (*BillProductQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return bp, nil
 	}
-	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return bp, nil
@@ -112,11 +112,11 @@ func newBillProductPaginateArgs(rv map[string]any) *billproductPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) (*CategoryQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return c, nil
 	}
-	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -419,11 +419,11 @@ func newCategoryPaginateArgs(rv map[string]any) *categoryPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string) (*FriendshipQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return f, nil
 	}
-	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return f, nil
@@ -526,11 +526,11 @@ func newFriendshipPaginateArgs(rv map[string]any) *friendshipPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*GroupQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return gr, nil
 	}
-	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return gr, nil
@@ -686,11 +686,11 @@ func newGroupPaginateArgs(rv map[string]any) *groupPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*TodoQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return t, nil
 	}
-	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -931,11 +931,11 @@ func newTodoPaginateArgs(rv map[string]any) *todoPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*UserQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return u, nil
 	}
-	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return u, nil

--- a/entgql/internal/todouuid/ent/gql_collection.go
+++ b/entgql/internal/todouuid/ent/gql_collection.go
@@ -35,11 +35,11 @@ import (
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (bp *BillProductQuery) CollectFields(ctx context.Context, satisfies ...string) (*BillProductQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return bp, nil
 	}
-	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := bp.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return bp, nil
@@ -112,11 +112,11 @@ func newBillProductPaginateArgs(rv map[string]any) *billproductPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (c *CategoryQuery) CollectFields(ctx context.Context, satisfies ...string) (*CategoryQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return c, nil
 	}
-	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := c.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -419,11 +419,11 @@ func newCategoryPaginateArgs(rv map[string]any) *categoryPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (f *FriendshipQuery) CollectFields(ctx context.Context, satisfies ...string) (*FriendshipQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return f, nil
 	}
-	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := f.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return f, nil
@@ -526,11 +526,11 @@ func newFriendshipPaginateArgs(rv map[string]any) *friendshipPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (gr *GroupQuery) CollectFields(ctx context.Context, satisfies ...string) (*GroupQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return gr, nil
 	}
-	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := gr.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return gr, nil
@@ -686,11 +686,11 @@ func newGroupPaginateArgs(rv map[string]any) *groupPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (t *TodoQuery) CollectFields(ctx context.Context, satisfies ...string) (*TodoQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return t, nil
 	}
-	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := t.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -931,11 +931,11 @@ func newTodoPaginateArgs(rv map[string]any) *todoPaginateArgs {
 
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func (u *UserQuery) CollectFields(ctx context.Context, satisfies ...string) (*UserQuery, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return u, nil
 	}
-	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := u.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return u, nil

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -28,11 +28,11 @@ import (
 {{ $query := $node.QueryName }}
 // CollectFields tells the query-builder to eagerly load connected nodes by resolver context.
 func ({{ $receiver }} *{{ $query }}) CollectFields(ctx context.Context, satisfies ...string) (*{{ $query }}, error) {
-	fc := graphql.GetFieldContext(ctx)
-	if fc == nil {
+	fieldContext := graphql.GetFieldContext(ctx)
+	if fieldContext == nil {
 		return {{ $receiver }}, nil
 	}
-	if err := {{ $receiver }}.collectField(ctx, false, graphql.GetOperationContext(ctx), fc.Field, nil, satisfies...); err != nil {
+	if err := {{ $receiver }}.collectField(ctx, false, graphql.GetOperationContext(ctx), fieldContext.Field, nil, satisfies...); err != nil {
 		return nil, err
 	}
 	return {{ $receiver }}, nil


### PR DESCRIPTION
This prevents name collisions in the `CollectFields` method for entities named `F*C*`. 

Same issue that was addressed in #572. I second the suggestion there to opt out of dynamic name generation for the receiver. This fixes it for the instance I ran into. 