### PR TITLE
[entgrpc] fix to get singular name

### DIFF
--- a/entproto/cmd/protoc-gen-entgrpc/template/method_mutate.tmpl
+++ b/entproto/cmd/protoc-gen-entgrpc/template/method_mutate.tmpl
@@ -81,7 +81,7 @@
                 {{- $varName  := camel .EntEdge.StructField }}
                 {{- $id := printf "item.Get%s()" .EdgeIDPbStructField }}
                 {{- template "field_to_ent" dict "Field" . "VarName" $varName "Ident" $id }}
-                m.Add{{ singular .EntEdge.StructField }}IDs({{ $varName }})
+                m.Add{{ singular .EntEdge.Name | pascal }}IDs({{ $varName }})
             }
         {{- end }}
     {{- end }}


### PR DESCRIPTION
`.EntEdge.StructField` has string value with pascal case so "Children" is stored which cannot be singulerized by the `sigular` function that only takes lower case.

`.EntEdge.Name` has same string with `.EntEdge.StructField` but lower case so "children" is stored; now `singular` returns "child". Also it needs to be transformed into pascalcase again.