### PR TITLE
ci: use node20 actions because node16 actions are deprecated

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Verify Generated
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           if ( "${{ inputs.working-directory }}" != "") {


### PR DESCRIPTION
If you use ent/contrib/ci action in GitHub Actions as follows, you will see a warning message.

```yaml
jobs:
  codegen-check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-go@v5
        with:
          go-version: 1.22
      - uses: ent/contrib/ci@master
```

<img width="1122" alt="スクリーンショット 2024-06-21 17 25 28" src="https://github.com/ent/contrib/assets/32762324/f2c9a5da-5607-4c72-8878-6639a51a5d4f">

This message is shown due to the use of deprecated node16 actions. Updating actions/github-script from v6 to v7 will resolve this issue. cf.) https://github.com/actions/github-script/releases/tag/v7.0.0


