### PR TITLE
add support for custom marshaller and custom output file

### DIFF
--- a/entoas/extension.go
+++ b/entoas/extension.go
@@ -73,7 +73,7 @@ type (
 func NewExtension(opts ...ExtensionOption) (*Extension, error) {
 	ex := &Extension{
 		marshalFn: func(v any) ([]byte, error) {
-			return json.MarshalIndent(v, "", " ")
+			return json.MarshalIndent(v, "", "  ")
 		},
 		outFile: "openapi.json",
 		config: &Config{


### PR DESCRIPTION
This PR adds support for specifying custom `Marshaller` and output file when initializing `entoas` extension. Sadly, only `github.com/go-faster/yaml` and `encoding/json` seem to work up to now.