### PR TITLE
entgql: make connection node non-null

### DIFF
--- a/entgql/internal/todo/ent.graphql
+++ b/entgql/internal/todo/ent.graphql
@@ -165,7 +165,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -373,7 +373,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -469,7 +469,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -561,7 +561,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -1032,7 +1032,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -1349,7 +1349,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """

--- a/entgql/internal/todo/generated.go
+++ b/entgql/internal/todo/generated.go
@@ -3174,11 +3174,14 @@ func (ec *executionContext) _CategoryEdge_node(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Category)
 	fc.Result = res
-	return ec.marshalOCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐCategory(ctx, field.Selections, res)
+	return ec.marshalNCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐCategory(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CategoryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3813,11 +3816,14 @@ func (ec *executionContext) _FriendshipEdge_node(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Friendship)
 	fc.Result = res
-	return ec.marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐFriendship(ctx, field.Selections, res)
+	return ec.marshalNFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐFriendship(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FriendshipEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4232,11 +4238,14 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Group)
 	fc.Result = res
-	return ec.marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroup(ctx, field.Selections, res)
+	return ec.marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroup(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GroupEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5071,11 +5080,14 @@ func (ec *executionContext) _OneToManyEdge_node(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.OneToMany)
 	fc.Result = res
-	return ec.marshalOOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐOneToMany(ctx, field.Selections, res)
+	return ec.marshalNOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐOneToMany(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OneToManyEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -7106,11 +7118,14 @@ func (ec *executionContext) _TodoEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Todo)
 	fc.Result = res
-	return ec.marshalOTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TodoEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -7774,11 +7789,14 @@ func (ec *executionContext) _UserEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.User)
 	fc.Result = res
-	return ec.marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -13341,6 +13359,9 @@ func (ec *executionContext) _CategoryEdge(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("CategoryEdge")
 		case "node":
 			out.Values[i] = ec._CategoryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._CategoryEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -13629,6 +13650,9 @@ func (ec *executionContext) _FriendshipEdge(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("FriendshipEdge")
 		case "node":
 			out.Values[i] = ec._FriendshipEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._FriendshipEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -13796,6 +13820,9 @@ func (ec *executionContext) _GroupEdge(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = graphql.MarshalString("GroupEdge")
 		case "node":
 			out.Values[i] = ec._GroupEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._GroupEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14072,6 +14099,9 @@ func (ec *executionContext) _OneToManyEdge(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("OneToManyEdge")
 		case "node":
 			out.Values[i] = ec._OneToManyEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._OneToManyEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14799,6 +14829,9 @@ func (ec *executionContext) _TodoEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("TodoEdge")
 		case "node":
 			out.Values[i] = ec._TodoEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._TodoEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15050,6 +15083,9 @@ func (ec *executionContext) _UserEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("UserEdge")
 		case "node":
 			out.Values[i] = ec._UserEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._UserEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15618,6 +15654,16 @@ func (ec *executionContext) marshalNFriendshipConnection2ᚖentgoᚗioᚋcontrib
 func (ec *executionContext) unmarshalNFriendshipWhereInput2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐFriendshipWhereInput(ctx context.Context, v interface{}) (*ent.FriendshipWhereInput, error) {
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGroupConnection2entgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroupConnection(ctx context.Context, sel ast.SelectionSet, v ent.GroupConnection) graphql.Marshaler {
@@ -16778,13 +16824,6 @@ func (ec *executionContext) marshalODuration2ᚖtimeᚐDuration(ctx context.Cont
 	return res
 }
 
-func (ec *executionContext) marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐFriendship(ctx context.Context, sel ast.SelectionSet, v *ent.Friendship) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Friendship(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOFriendshipEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐFriendshipEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.FriendshipEdge) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -16859,13 +16898,6 @@ func (ec *executionContext) unmarshalOFriendshipWhereInput2ᚖentgoᚗioᚋcontr
 	}
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOGroupEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐGroupEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.GroupEdge) graphql.Marshaler {
@@ -17709,13 +17741,6 @@ func (ec *executionContext) marshalOUint642ᚖuint64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalUint64(*v)
 	return res
-}
-
-func (ec *executionContext) marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐUser(ctx context.Context, sel ast.SelectionSet, v *ent.User) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUserEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodoᚋentᚐUserEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.UserEdge) graphql.Marshaler {

--- a/entgql/internal/todogotype/generated.go
+++ b/entgql/internal/todogotype/generated.go
@@ -1566,7 +1566,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -1774,7 +1774,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -1870,7 +1870,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -1962,7 +1962,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -2433,7 +2433,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -2750,7 +2750,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """
@@ -4729,11 +4729,14 @@ func (ec *executionContext) _CategoryEdge_node(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Category)
 	fc.Result = res
-	return ec.marshalOCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐCategory(ctx, field.Selections, res)
+	return ec.marshalNCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐCategory(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CategoryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5368,11 +5371,14 @@ func (ec *executionContext) _FriendshipEdge_node(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Friendship)
 	fc.Result = res
-	return ec.marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐFriendship(ctx, field.Selections, res)
+	return ec.marshalNFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐFriendship(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FriendshipEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5787,11 +5793,14 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Group)
 	fc.Result = res
-	return ec.marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroup(ctx, field.Selections, res)
+	return ec.marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroup(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GroupEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -6626,11 +6635,14 @@ func (ec *executionContext) _OneToManyEdge_node(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*OneToMany)
 	fc.Result = res
-	return ec.marshalOOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚐOneToMany(ctx, field.Selections, res)
+	return ec.marshalNOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚐOneToMany(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OneToManyEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8661,11 +8673,14 @@ func (ec *executionContext) _TodoEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Todo)
 	fc.Result = res
-	return ec.marshalOTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TodoEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9329,11 +9344,14 @@ func (ec *executionContext) _UserEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.User)
 	fc.Result = res
-	return ec.marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14963,6 +14981,9 @@ func (ec *executionContext) _CategoryEdge(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("CategoryEdge")
 		case "node":
 			out.Values[i] = ec._CategoryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._CategoryEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15251,6 +15272,9 @@ func (ec *executionContext) _FriendshipEdge(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("FriendshipEdge")
 		case "node":
 			out.Values[i] = ec._FriendshipEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._FriendshipEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15418,6 +15442,9 @@ func (ec *executionContext) _GroupEdge(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = graphql.MarshalString("GroupEdge")
 		case "node":
 			out.Values[i] = ec._GroupEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._GroupEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15632,6 +15659,9 @@ func (ec *executionContext) _OneToManyEdge(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("OneToManyEdge")
 		case "node":
 			out.Values[i] = ec._OneToManyEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._OneToManyEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16390,6 +16420,9 @@ func (ec *executionContext) _TodoEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("TodoEdge")
 		case "node":
 			out.Values[i] = ec._TodoEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._TodoEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16734,6 +16767,9 @@ func (ec *executionContext) _UserEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("UserEdge")
 		case "node":
 			out.Values[i] = ec._UserEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._UserEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -17306,6 +17342,16 @@ func (ec *executionContext) marshalNFriendshipConnection2ᚖentgoᚗioᚋcontrib
 func (ec *executionContext) unmarshalNFriendshipWhereInput2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐFriendshipWhereInput(ctx context.Context, v interface{}) (*ent.FriendshipWhereInput, error) {
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGroupConnection2entgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroupConnection(ctx context.Context, sel ast.SelectionSet, v ent.GroupConnection) graphql.Marshaler {
@@ -18480,13 +18526,6 @@ func (ec *executionContext) marshalODuration2ᚖtimeᚐDuration(ctx context.Cont
 	return res
 }
 
-func (ec *executionContext) marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐFriendship(ctx context.Context, sel ast.SelectionSet, v *ent.Friendship) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Friendship(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOFriendshipEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐFriendshipEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.FriendshipEdge) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -18561,13 +18600,6 @@ func (ec *executionContext) unmarshalOFriendshipWhereInput2ᚖentgoᚗioᚋcontr
 	}
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOGroupEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐGroupEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.GroupEdge) graphql.Marshaler {
@@ -19455,13 +19487,6 @@ func (ec *executionContext) marshalOUint642ᚖuint64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalUint64(*v)
 	return res
-}
-
-func (ec *executionContext) marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐUser(ctx context.Context, sel ast.SelectionSet, v *ent.User) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUserEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodogotypeᚋentᚐUserEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.UserEdge) graphql.Marshaler {

--- a/entgql/internal/todogotype/models_gen.go
+++ b/entgql/internal/todogotype/models_gen.go
@@ -59,7 +59,7 @@ type OneToManyConnection struct {
 // An edge in a connection.
 type OneToManyEdge struct {
 	// The item at the end of the edge.
-	Node *OneToMany `json:"node,omitempty"`
+	Node *OneToMany `json:"node"`
 	// A cursor for use in pagination.
 	Cursor entgql.Cursor[string] `json:"cursor"`
 }

--- a/entgql/internal/todopulid/generated.go
+++ b/entgql/internal/todopulid/generated.go
@@ -1572,7 +1572,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -1780,7 +1780,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -1876,7 +1876,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -1968,7 +1968,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -2439,7 +2439,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -2756,7 +2756,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """
@@ -4735,11 +4735,14 @@ func (ec *executionContext) _CategoryEdge_node(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Category)
 	fc.Result = res
-	return ec.marshalOCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐCategory(ctx, field.Selections, res)
+	return ec.marshalNCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐCategory(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CategoryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5374,11 +5377,14 @@ func (ec *executionContext) _FriendshipEdge_node(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Friendship)
 	fc.Result = res
-	return ec.marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐFriendship(ctx, field.Selections, res)
+	return ec.marshalNFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐFriendship(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FriendshipEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5793,11 +5799,14 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Group)
 	fc.Result = res
-	return ec.marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroup(ctx, field.Selections, res)
+	return ec.marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroup(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GroupEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -6632,11 +6641,14 @@ func (ec *executionContext) _OneToManyEdge_node(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*OneToMany)
 	fc.Result = res
-	return ec.marshalOOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚐOneToMany(ctx, field.Selections, res)
+	return ec.marshalNOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚐOneToMany(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OneToManyEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8667,11 +8679,14 @@ func (ec *executionContext) _TodoEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Todo)
 	fc.Result = res
-	return ec.marshalOTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TodoEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9335,11 +9350,14 @@ func (ec *executionContext) _UserEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.User)
 	fc.Result = res
-	return ec.marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14973,6 +14991,9 @@ func (ec *executionContext) _CategoryEdge(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("CategoryEdge")
 		case "node":
 			out.Values[i] = ec._CategoryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._CategoryEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15261,6 +15282,9 @@ func (ec *executionContext) _FriendshipEdge(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("FriendshipEdge")
 		case "node":
 			out.Values[i] = ec._FriendshipEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._FriendshipEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15428,6 +15452,9 @@ func (ec *executionContext) _GroupEdge(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = graphql.MarshalString("GroupEdge")
 		case "node":
 			out.Values[i] = ec._GroupEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._GroupEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15642,6 +15669,9 @@ func (ec *executionContext) _OneToManyEdge(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("OneToManyEdge")
 		case "node":
 			out.Values[i] = ec._OneToManyEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._OneToManyEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16400,6 +16430,9 @@ func (ec *executionContext) _TodoEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("TodoEdge")
 		case "node":
 			out.Values[i] = ec._TodoEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._TodoEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16682,6 +16715,9 @@ func (ec *executionContext) _UserEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("UserEdge")
 		case "node":
 			out.Values[i] = ec._UserEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._UserEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -17254,6 +17290,16 @@ func (ec *executionContext) marshalNFriendshipConnection2ᚖentgoᚗioᚋcontrib
 func (ec *executionContext) unmarshalNFriendshipWhereInput2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐFriendshipWhereInput(ctx context.Context, v interface{}) (*ent.FriendshipWhereInput, error) {
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGroupConnection2entgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroupConnection(ctx context.Context, sel ast.SelectionSet, v ent.GroupConnection) graphql.Marshaler {
@@ -18413,13 +18459,6 @@ func (ec *executionContext) marshalODuration2ᚖtimeᚐDuration(ctx context.Cont
 	return res
 }
 
-func (ec *executionContext) marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐFriendship(ctx context.Context, sel ast.SelectionSet, v *ent.Friendship) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Friendship(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOFriendshipEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐFriendshipEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.FriendshipEdge) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -18494,13 +18533,6 @@ func (ec *executionContext) unmarshalOFriendshipWhereInput2ᚖentgoᚗioᚋcontr
 	}
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOGroupEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐGroupEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.GroupEdge) graphql.Marshaler {
@@ -19334,13 +19366,6 @@ func (ec *executionContext) marshalOUint642ᚖuint64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalUint64(*v)
 	return res
-}
-
-func (ec *executionContext) marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐUser(ctx context.Context, sel ast.SelectionSet, v *ent.User) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUserEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodopulidᚋentᚐUserEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.UserEdge) graphql.Marshaler {

--- a/entgql/internal/todopulid/models_gen.go
+++ b/entgql/internal/todopulid/models_gen.go
@@ -48,7 +48,7 @@ type OneToManyConnection struct {
 // An edge in a connection.
 type OneToManyEdge struct {
 	// The item at the end of the edge.
-	Node *OneToMany `json:"node,omitempty"`
+	Node *OneToMany `json:"node"`
 	// A cursor for use in pagination.
 	Cursor entgql.Cursor[pulid.ID] `json:"cursor"`
 }

--- a/entgql/internal/todouuid/generated.go
+++ b/entgql/internal/todouuid/generated.go
@@ -1573,7 +1573,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -1781,7 +1781,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -1877,7 +1877,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -1969,7 +1969,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -2440,7 +2440,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -2757,7 +2757,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """
@@ -4736,11 +4736,14 @@ func (ec *executionContext) _CategoryEdge_node(ctx context.Context, field graphq
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Category)
 	fc.Result = res
-	return ec.marshalOCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐCategory(ctx, field.Selections, res)
+	return ec.marshalNCategory2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐCategory(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CategoryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5375,11 +5378,14 @@ func (ec *executionContext) _FriendshipEdge_node(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Friendship)
 	fc.Result = res
-	return ec.marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐFriendship(ctx, field.Selections, res)
+	return ec.marshalNFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐFriendship(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FriendshipEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5794,11 +5800,14 @@ func (ec *executionContext) _GroupEdge_node(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Group)
 	fc.Result = res
-	return ec.marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroup(ctx, field.Selections, res)
+	return ec.marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroup(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GroupEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -6633,11 +6642,14 @@ func (ec *executionContext) _OneToManyEdge_node(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*OneToMany)
 	fc.Result = res
-	return ec.marshalOOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚐOneToMany(ctx, field.Selections, res)
+	return ec.marshalNOneToMany2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚐOneToMany(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_OneToManyEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8668,11 +8680,14 @@ func (ec *executionContext) _TodoEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.Todo)
 	fc.Result = res
-	return ec.marshalOTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐTodo(ctx, field.Selections, res)
+	return ec.marshalNTodo2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐTodo(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TodoEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9336,11 +9351,14 @@ func (ec *executionContext) _UserEdge_node(ctx context.Context, field graphql.Co
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*ent.User)
 	fc.Result = res
-	return ec.marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14974,6 +14992,9 @@ func (ec *executionContext) _CategoryEdge(ctx context.Context, sel ast.Selection
 			out.Values[i] = graphql.MarshalString("CategoryEdge")
 		case "node":
 			out.Values[i] = ec._CategoryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._CategoryEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15262,6 +15283,9 @@ func (ec *executionContext) _FriendshipEdge(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("FriendshipEdge")
 		case "node":
 			out.Values[i] = ec._FriendshipEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._FriendshipEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15429,6 +15453,9 @@ func (ec *executionContext) _GroupEdge(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = graphql.MarshalString("GroupEdge")
 		case "node":
 			out.Values[i] = ec._GroupEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._GroupEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15643,6 +15670,9 @@ func (ec *executionContext) _OneToManyEdge(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("OneToManyEdge")
 		case "node":
 			out.Values[i] = ec._OneToManyEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._OneToManyEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16401,6 +16431,9 @@ func (ec *executionContext) _TodoEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("TodoEdge")
 		case "node":
 			out.Values[i] = ec._TodoEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._TodoEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16683,6 +16716,9 @@ func (ec *executionContext) _UserEdge(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = graphql.MarshalString("UserEdge")
 		case "node":
 			out.Values[i] = ec._UserEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "cursor":
 			out.Values[i] = ec._UserEdge_cursor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -17255,6 +17291,16 @@ func (ec *executionContext) marshalNFriendshipConnection2ᚖentgoᚗioᚋcontrib
 func (ec *executionContext) unmarshalNFriendshipWhereInput2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐFriendshipWhereInput(ctx context.Context, v interface{}) (*ent.FriendshipWhereInput, error) {
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNGroupConnection2entgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroupConnection(ctx context.Context, sel ast.SelectionSet, v ent.GroupConnection) graphql.Marshaler {
@@ -18419,13 +18465,6 @@ func (ec *executionContext) marshalODuration2ᚖtimeᚐDuration(ctx context.Cont
 	return res
 }
 
-func (ec *executionContext) marshalOFriendship2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐFriendship(ctx context.Context, sel ast.SelectionSet, v *ent.Friendship) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Friendship(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOFriendshipEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐFriendshipEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.FriendshipEdge) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -18500,13 +18539,6 @@ func (ec *executionContext) unmarshalOFriendshipWhereInput2ᚖentgoᚗioᚋcontr
 	}
 	res, err := ec.unmarshalInputFriendshipWhereInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOGroup2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroup(ctx context.Context, sel ast.SelectionSet, v *ent.Group) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Group(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOGroupEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐGroupEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.GroupEdge) graphql.Marshaler {
@@ -19340,13 +19372,6 @@ func (ec *executionContext) marshalOUint642ᚖuint64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalUint64(*v)
 	return res
-}
-
-func (ec *executionContext) marshalOUser2ᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐUser(ctx context.Context, sel ast.SelectionSet, v *ent.User) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUserEdge2ᚕᚖentgoᚗioᚋcontribᚋentgqlᚋinternalᚋtodouuidᚋentᚐUserEdge(ctx context.Context, sel ast.SelectionSet, v []*ent.UserEdge) graphql.Marshaler {

--- a/entgql/internal/todouuid/models_gen.go
+++ b/entgql/internal/todouuid/models_gen.go
@@ -48,7 +48,7 @@ type OneToManyConnection struct {
 // An edge in a connection.
 type OneToManyEdge struct {
 	// The item at the end of the edge.
-	Node *OneToMany `json:"node,omitempty"`
+	Node *OneToMany `json:"node"`
 	// A cursor for use in pagination.
 	Cursor entgql.Cursor[uuid.UUID] `json:"cursor"`
 }

--- a/entgql/schema_test.go
+++ b/entgql/schema_test.go
@@ -113,7 +113,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -157,7 +157,7 @@ type SuperTodoEdge {
   """
   The item at the end of the edge.
   """
-  node: SuperTodo
+  node: SuperTodo!
   """
   A cursor for use in pagination.
   """

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -573,7 +573,7 @@ func (p *PaginationNames) TypeDefs() []*ast.Definition {
 			Fields: []*ast.FieldDefinition{
 				{
 					Name:        "node",
-					Type:        ast.NamedType(p.Node, nil),
+					Type:        ast.NonNullNamedType(p.Node, nil),
 					Description: "The item at the end of the edge.",
 				},
 				{

--- a/entgql/testdata/schema_relay.graphql
+++ b/entgql/testdata/schema_relay.graphql
@@ -163,7 +163,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -366,7 +366,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -462,7 +462,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -544,7 +544,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -980,7 +980,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -1297,7 +1297,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """

--- a/entgql/testdata/schema_relay_output.graphql
+++ b/entgql/testdata/schema_relay_output.graphql
@@ -163,7 +163,7 @@ type CategoryEdge {
   """
   The item at the end of the edge.
   """
-  node: Category
+  node: Category!
   """
   A cursor for use in pagination.
   """
@@ -366,7 +366,7 @@ type FriendshipEdge {
   """
   The item at the end of the edge.
   """
-  node: Friendship
+  node: Friendship!
   """
   A cursor for use in pagination.
   """
@@ -462,7 +462,7 @@ type GroupEdge {
   """
   The item at the end of the edge.
   """
-  node: Group
+  node: Group!
   """
   A cursor for use in pagination.
   """
@@ -544,7 +544,7 @@ type OneToManyEdge {
   """
   The item at the end of the edge.
   """
-  node: OneToMany
+  node: OneToMany!
   """
   A cursor for use in pagination.
   """
@@ -980,7 +980,7 @@ type TodoEdge {
   """
   The item at the end of the edge.
   """
-  node: Todo
+  node: Todo!
   """
   A cursor for use in pagination.
   """
@@ -1297,7 +1297,7 @@ type UserEdge {
   """
   The item at the end of the edge.
   """
-  node: User
+  node: User!
   """
   A cursor for use in pagination.
   """


### PR DESCRIPTION
https://github.com/ent/ent/issues/3998

## What's changed

Generates `node` field in connection edge types as non-null types.

## Background

According to [the spec](https://relay.dev/graphql/connections.htm), `node` field can be non-null.

> An “Edge Type” must contain a field called node. This field must return either a Scalar, Enum, Object, Interface, Union, **or a Non-Null wrapper around one of those types**. Notably, this field cannot return a list.
> https://relay.dev/graphql/connections.htm#sel-FAHFFDCAACEP0xF

On the other hand, `edges` field in connection types are defined as just *a list type that wraps an edge type*, which means `[Edge]` but not `[Edge]!`.

> A “Connection Type” must contain a field called edges. This field must return **a list type that wraps an edge type**, where the requirements of an edge type are defined in the “Edge Types” section below.
> https://relay.dev/graphql/connections.htm#sel-FAFFFDCAACCzEsY

So this PR only changes `node` field and keeps `edges` field as it is.

## Concerns

My concern is whether we should consider this a breaking change.

GraphQL API clients can accept the transition from nullable to non-null fields without any change or breaking.

How about servers? I'm not sure this change would break server implementations using ent.

If so, we can introduce this change as an option.