### PR TITLE
entgql: support SkipMutationCreateInput (and update) on entity

### DIFF
--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -546,6 +546,13 @@ func (e *schemaGenerator) buildMutationInputs(t *gen.Type, ant *Annotation, gqlT
 	var defs []*ast.Definition
 
 	for _, i := range ant.MutationInputs {
+		if i.IsCreate && ant.Skip.Is(SkipMutationCreateInput) {
+			continue
+		}
+		if !i.IsCreate && ant.Skip.Is(SkipMutationUpdateInput) {
+			continue
+		}
+
 		desc := MutationDescriptor{Type: t, IsCreate: i.IsCreate}
 		name, err := desc.Input()
 		if err != nil {


### PR DESCRIPTION
Before this change, when SkipMutationCreateInput was annotated on an entity, the CreateXxxInput was omitted from the `gql_mutation_input.go` generated types, but still included in the `ent.graphql` generated schema. The same was true for SkipMutationUpdateInput.

To work around this, you could use entgql.Mutations to select only the ones you want generated. But, according to the annotation comments, using SkipMutationCreateInput in this way should be supported.

For example, this works as expected:

```go
func (File) Annotations() []schema.Annotation {
	return []schema.Annotation{
		entgql.Mutations(entgql.MutationUpdate()),
	}
}
```

While this does not (it still generates CreateFileInput in ent.graphql):

```go
func (File) Annotations() []schema.Annotation {
	return []schema.Annotation{
		entgql.Mutations(),
		entgql.Skip(entgql.SkipMutationCreateInput),
	}
}
```


This change adds the proper checks to buildMutationInputs to omit the specified mutation inputs from the GraphQL schema.

There are no entities in the example code using a skip annotation at the entity level.