### PR TITLE
entgql: fixed zero value on `first`/`last` when receive `null` input

### DIFF
--- a/entgql/internal/todo/ent/gql_collection.go
+++ b/entgql/internal/todo/ent/gql_collection.go
@@ -1663,7 +1663,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/entgql/internal/todofed/ent/gql_collection.go
+++ b/entgql/internal/todofed/ent/gql_collection.go
@@ -315,7 +315,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/entgql/internal/todogotype/ent/gql_collection.go
+++ b/entgql/internal/todogotype/ent/gql_collection.go
@@ -1230,7 +1230,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/entgql/internal/todopulid/ent/gql_collection.go
+++ b/entgql/internal/todopulid/ent/gql_collection.go
@@ -1177,7 +1177,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/entgql/internal/todouuid/ent/gql_collection.go
+++ b/entgql/internal/todouuid/ent/gql_collection.go
@@ -1177,7 +1177,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -299,7 +299,7 @@ func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]a
 func unmarshalArgs(ctx context.Context, whereInput any, args map[string]any) map[string]any {
 	for _, k := range []string{firstField, lastField} {
 		v, ok := args[k]
-		if !ok {
+		if !ok || v == nil {
 			continue
 		}
 		i, err := graphql.UnmarshalInt(v)


### PR DESCRIPTION
GQLGen changed its behavior in https://github.com/99designs/gqlgen/pull/3162 to return a zero value for `null`.

Which causes `first` / `last` to receive the 0 value, and fail the check for supplying both `first` and `last`
