### PR TITLE
feat: add Proto3Optional support

### DIFF
--- a/entproto/adapter.go
+++ b/entproto/adapter.go
@@ -80,7 +80,7 @@ type Adapter struct {
 
 // AdapterOptions are options for the Adapter
 type AdapterOptions struct {
-	OptionalEnable bool
+	Proto3Optional bool
 }
 
 // AllFileDescriptors returns a file descriptor per proto package for each package that contains
@@ -504,7 +504,7 @@ func extractProtoTypeDetails(f *gen.Field, options *AdapterOptions) (fieldType, 
 	if !ok || cfg.unsupported {
 		return fieldType{}, unsupportedTypeError{Type: f.Type}
 	}
-	if f.Optional && !options.OptionalEnable {
+	if f.Optional && !options.Proto3Optional {
 		if cfg.optionalType == "" {
 			return fieldType{}, unsupportedTypeError{Type: f.Type}
 		}
@@ -520,7 +520,7 @@ func extractProtoTypeDetails(f *gen.Field, options *AdapterOptions) (fieldType, 
 	return fieldType{
 		protoType:   cfg.pbType,
 		messageName: name,
-		optional:    options.OptionalEnable && f.Optional,
+		optional:    options.Proto3Optional && f.Optional,
 	}, nil
 }
 

--- a/entproto/adapter.go
+++ b/entproto/adapter.go
@@ -17,6 +17,7 @@ package entproto
 import (
 	"errors"
 	"fmt"
+	"google.golang.org/protobuf/proto"
 	"path"
 	"path/filepath"
 	"strings"
@@ -39,7 +40,6 @@ const (
 var (
 	ErrSchemaSkipped   = errors.New("entproto: schema not annotated with Generate=true")
 	repeatedFieldLabel = descriptorpb.FieldDescriptorProto_LABEL_REPEATED
-	optinalFieldLabel  = descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
 	wktsPaths          = map[string]string{
 		// TODO: handle more Well-Known proto types
 		"google.protobuf.Timestamp":   "google/protobuf/timestamp.proto",
@@ -490,7 +490,7 @@ func toProtoFieldDescriptor(f *gen.Field, options *AdapterOptions) (*descriptorp
 	if typeDetails.repeated {
 		fieldDesc.Label = &repeatedFieldLabel
 	} else if typeDetails.optional {
-		fieldDesc.Label = &optinalFieldLabel
+		fieldDesc.Proto3Optional = proto.Bool(true)
 	}
 
 	return fieldDesc, nil

--- a/entproto/cmd/protoc-gen-entgrpc/main.go
+++ b/entproto/cmd/protoc-gen-entgrpc/main.go
@@ -39,6 +39,7 @@ var (
 func main() {
 	var flags flag.FlagSet
 	entSchemaPath = flags.String("schema_path", "", "ent schema path")
+	optionalEnable := flags.Bool("optional", false, "proto optional keyword enabled")
 	protogen.Options{
 		ParamFunc: flags.Set,
 	}.Run(func(plg *protogen.Plugin) error {
@@ -50,7 +51,10 @@ func main() {
 			if !f.Generate {
 				continue
 			}
-			if err := processFile(plg, f, g); err != nil {
+			options := &entproto.AdapterOptions{
+				OptionalEnable: *optionalEnable,
+			}
+			if err := processFile(plg, f, g, options); err != nil {
 				return err
 			}
 		}
@@ -59,11 +63,11 @@ func main() {
 }
 
 // processFile generates service implementations from all services defined in the file.
-func processFile(gen *protogen.Plugin, file *protogen.File, graph *gen.Graph) error {
+func processFile(gen *protogen.Plugin, file *protogen.File, graph *gen.Graph, options *entproto.AdapterOptions) error {
 	if len(file.Services) == 0 {
 		return nil
 	}
-	adapter, err := entproto.LoadAdapter(graph)
+	adapter, err := entproto.LoadAdapter(graph, options)
 	if err != nil {
 		return err
 	}

--- a/entproto/cmd/protoc-gen-entgrpc/main.go
+++ b/entproto/cmd/protoc-gen-entgrpc/main.go
@@ -52,7 +52,7 @@ func main() {
 				continue
 			}
 			options := &entproto.AdapterOptions{
-				OptionalEnable: *optionalEnable,
+				Proto3Optional: *optionalEnable,
 			}
 			if err := processFile(plg, f, g, options); err != nil {
 				return err

--- a/entproto/extension.go
+++ b/entproto/extension.go
@@ -56,8 +56,9 @@ func NewExtension(opts ...ExtensionOption) (*Extension, error) {
 //	}
 type Extension struct {
 	entc.DefaultExtension
-	protoDir    string
-	skipGenFile bool
+	protoDir        string
+	skipGenFile     bool
+	optionalEnabled bool
 }
 
 // WithProtoDir sets the directory where the generated .proto files will be written.
@@ -71,6 +72,13 @@ func WithProtoDir(dir string) ExtensionOption {
 func SkipGenFile() ExtensionOption {
 	return func(e *Extension) {
 		e.skipGenFile = true
+	}
+}
+
+// EnableOptional enables the generation of optional fields in the .proto files.
+func EnableOptional() ExtensionOption {
+	return func(e *Extension) {
+		e.optionalEnabled = true
 	}
 }
 
@@ -124,7 +132,9 @@ func (e *Extension) generate(g *gen.Graph) error {
 	if e.protoDir != "" {
 		entProtoDir = e.protoDir
 	}
-	adapter, err := LoadAdapter(g)
+	adapter, err := LoadAdapter(g, &AdapterOptions{
+		OptionalEnable: e.optionalEnabled,
+	})
 	if err != nil {
 		return fmt.Errorf("entproto: failed parsing ent graph: %w", err)
 	}

--- a/entproto/extension.go
+++ b/entproto/extension.go
@@ -56,9 +56,9 @@ func NewExtension(opts ...ExtensionOption) (*Extension, error) {
 //	}
 type Extension struct {
 	entc.DefaultExtension
-	protoDir        string
-	skipGenFile     bool
-	optionalEnabled bool
+	protoDir       string
+	skipGenFile    bool
+	Proto3Optional bool
 }
 
 // WithProtoDir sets the directory where the generated .proto files will be written.
@@ -78,7 +78,7 @@ func SkipGenFile() ExtensionOption {
 // EnableOptional enables the generation of optional fields in the .proto files.
 func EnableOptional() ExtensionOption {
 	return func(e *Extension) {
-		e.optionalEnabled = true
+		e.Proto3Optional = true
 	}
 }
 
@@ -133,7 +133,7 @@ func (e *Extension) Generate(g *gen.Graph) error {
 		entProtoDir = e.protoDir
 	}
 	adapter, err := LoadAdapter(g, &AdapterOptions{
-		OptionalEnable: e.optionalEnabled,
+		Proto3Optional: e.Proto3Optional,
 	})
 	if err != nil {
 		return fmt.Errorf("entproto: failed parsing ent graph: %w", err)

--- a/entproto/extension.go
+++ b/entproto/extension.go
@@ -97,7 +97,7 @@ func (e *Extension) hook() gen.Hook {
 			if err != nil {
 				return err
 			}
-			return e.generate(g)
+			return e.Generate(g)
 		})
 	}
 }
@@ -124,10 +124,10 @@ func Hook() gen.Hook {
 // To disable the generation of the generate.go file, use the `entproto.SkipGenFile()` option.
 func Generate(g *gen.Graph) error {
 	x := &Extension{}
-	return x.generate(g)
+	return x.Generate(g)
 }
 
-func (e *Extension) generate(g *gen.Graph) error {
+func (e *Extension) Generate(g *gen.Graph) error {
 	entProtoDir := path.Join(g.Config.Target, "proto")
 	if e.protoDir != "" {
 		entProtoDir = e.protoDir

--- a/entproto/service.go
+++ b/entproto/service.go
@@ -92,7 +92,7 @@ func Service(opts ...ServiceOption) schema.Annotation {
 	return s
 }
 
-func (a *Adapter) createServiceResources(genType *gen.Type, methods Method) (serviceResources, error) {
+func (a *Adapter) createServiceResources(genType *gen.Type, methods Method, options *AdapterOptions) (serviceResources, error) {
 	name := genType.Name
 	serviceFqn := fmt.Sprintf("%sService", name)
 
@@ -107,7 +107,7 @@ func (a *Adapter) createServiceResources(genType *gen.Type, methods Method) (ser
 			continue
 		}
 
-		resources, err := a.genMethodProtos(genType, m)
+		resources, err := a.genMethodProtos(genType, m, options)
 		if err != nil {
 			return serviceResources{}, err
 		}
@@ -121,9 +121,9 @@ func (a *Adapter) createServiceResources(genType *gen.Type, methods Method) (ser
 
 var plural = gen.Funcs["plural"].(func(string) string)
 
-func (a *Adapter) genMethodProtos(genType *gen.Type, m Method) (methodResources, error) {
+func (a *Adapter) genMethodProtos(genType *gen.Type, m Method, options *AdapterOptions) (methodResources, error) {
 	input := &descriptorpb.DescriptorProto{}
-	idField, err := toProtoFieldDescriptor(genType.ID)
+	idField, err := toProtoFieldDescriptor(genType.ID, options)
 	if err != nil {
 		return methodResources{}, err
 	}


### PR DESCRIPTION
Starting from version 3.15 of protobuf, proto3 reintroduced support for the "optional" keyword.

So I added a configuration to decide whether to enable this feature.