### PR TITLE
ability to add additonal fields and funcs to mutation input

### DIFF
--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -55,6 +55,12 @@ import (
                 {{- end }}
             {{- end }}
         {{- end }}
+
+        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/model/fields/*"  }}
+            {{- range $tmpl := $tmpls }}
+                {{- xtemplate $tmpl $n }}
+            {{- end }}
+        {{- end }}
     }
 
     // Mutate applies the {{ $input }} on the {{ $n.MutationName }} builder.
@@ -108,6 +114,12 @@ import (
                         m.{{ $e.MutationRemove }}(v...)
                     }
                 {{- end }}
+            {{- end }}
+        {{- end }}
+
+        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/mutate/*"  }}
+            {{- range $tmpl := $tmpls }}
+                {{- xtemplate $tmpl $n }}
             {{- end }}
         {{- end }}
     }

--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -56,7 +56,7 @@ import (
             {{- end }}
         {{- end }}
 
-        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/model/fields/*"  }}
+        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/fields/*"  }}
             {{- range $tmpl := $tmpls }}
                 {{- xtemplate $tmpl $n }}
             {{- end }}


### PR DESCRIPTION
Refer: https://github.com/ent/ent/pull/4281

I am building a Media Extension need to set Fields on e.g PostMutation via `saas/gen/ent/gql_mutation_input.go`

So instead of copying the whole template file and overriding, we should be able to override within the default template from the vendor directory.

and also this way multiple custom extensions can add additional fields and make it modular.