### PR TITLE
fix: remove duplicate graphql import in generated files

### DIFF
--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -15,7 +15,6 @@ in the LICENSE file in the root directory of this source tree.
 
 import (
 	"entgo.io/contrib/entgql"
-	"github.com/99designs/gqlgen/graphql"
 	{{- range $n := $gqlNodes }}
 		"{{ $.Config.Package }}/{{ $n.Package }}"
 	{{- end }}

--- a/entgql/template/edge.tmpl
+++ b/entgql/template/edge.tmpl
@@ -15,7 +15,6 @@ import (
 	"context"
 
 	"entgo.io/contrib/entgql"
-	"github.com/99designs/gqlgen/graphql"
 )
 
 {{ range $n := filterNodes $.Nodes (skipMode "type") }}

--- a/entgql/template/node.tmpl
+++ b/entgql/template/node.tmpl
@@ -40,7 +40,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/schema"
 	"entgo.io/contrib/entgql"
-	"github.com/99designs/gqlgen/graphql"
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/semaphore"
 )

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -34,7 +34,6 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/contrib/entgql"
-	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/errcode"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vmihailenco/msgpack/v5"


### PR DESCRIPTION
The graphql package was being imported twice in generated files — once via the import/additional/graphql-enum hook defined in enum.tmpl, and again in the explicit import blocks of node.tmpl, pagination.tmpl, collection.tmpl, and edge.tmpl.