### PR TITLE
entgql: fix update input Mutate to append MutationAppend field

### DIFF
--- a/entgql/internal/todo/ent/gql_mutation_input.go
+++ b/entgql/internal/todo/ent/gql_mutation_input.go
@@ -140,7 +140,7 @@ func (i *UpdateCategoryInput) Mutate(m *CategoryMutation) {
 		m.SetStrings(v)
 	}
 	if i.AppendStrings != nil {
-		m.AppendStrings(i.Strings)
+		m.AppendStrings(i.AppendStrings)
 	}
 	if i.ClearTodos {
 		m.ClearTodos()

--- a/entgql/internal/todoglobalid/ent/gql_mutation_input.go
+++ b/entgql/internal/todoglobalid/ent/gql_mutation_input.go
@@ -133,7 +133,7 @@ func (i *UpdateCategoryInput) Mutate(m *CategoryMutation) {
 		m.SetStrings(v)
 	}
 	if i.AppendStrings != nil {
-		m.AppendStrings(i.Strings)
+		m.AppendStrings(i.AppendStrings)
 	}
 	if i.ClearTodos {
 		m.ClearTodos()

--- a/entgql/internal/todogotype/ent/gql_mutation_input.go
+++ b/entgql/internal/todogotype/ent/gql_mutation_input.go
@@ -140,7 +140,7 @@ func (i *UpdateCategoryInput) Mutate(m *CategoryMutation) {
 		m.SetStrings(v)
 	}
 	if i.AppendStrings != nil {
-		m.AppendStrings(i.Strings)
+		m.AppendStrings(i.AppendStrings)
 	}
 	if i.ClearTodos {
 		m.ClearTodos()

--- a/entgql/internal/todopulid/ent/gql_mutation_input.go
+++ b/entgql/internal/todopulid/ent/gql_mutation_input.go
@@ -141,7 +141,7 @@ func (i *UpdateCategoryInput) Mutate(m *CategoryMutation) {
 		m.SetStrings(v)
 	}
 	if i.AppendStrings != nil {
-		m.AppendStrings(i.Strings)
+		m.AppendStrings(i.AppendStrings)
 	}
 	if i.ClearTodos {
 		m.ClearTodos()

--- a/entgql/internal/todouuid/ent/gql_mutation_input.go
+++ b/entgql/internal/todouuid/ent/gql_mutation_input.go
@@ -140,7 +140,7 @@ func (i *UpdateCategoryInput) Mutate(m *CategoryMutation) {
 		m.SetStrings(v)
 	}
 	if i.AppendStrings != nil {
-		m.AppendStrings(i.Strings)
+		m.AppendStrings(i.AppendStrings)
 	}
 	if i.ClearTodos {
 		m.ClearTodos()

--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -81,7 +81,7 @@ import (
             {{- end }}
             {{- if $f.AppendOp }}
                 if i.{{ $f.MutationAppend }} != nil {
-                    m.{{ $f.MutationAppend }}({{ if $f.IsPointer }}*{{ end }}i.{{ $f.StructField }})
+                    m.{{ $f.MutationAppend }}({{ if $f.IsPointer }}*{{ end }}i.{{ $f.MutationAppend }})
                 }
             {{- end }}
         {{- end }}


### PR DESCRIPTION
Append ops were checking Append<field> but passing the set StructField into the mutation, so append-only updates were a no-op.